### PR TITLE
Fix artifacts not loading and add option for scenario 5

### DIFF
--- a/aws-kubeflow-kserve/locals.tf
+++ b/aws-kubeflow-kserve/locals.tf
@@ -24,7 +24,8 @@ locals {
     service_account_name = "kserve-sa"
   }
   mlflow = {
-    artifact_S3 = "true"
+    artifact_Proxied_Access = "false"
+    artifact_S3             = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_S3_Bucket = ""
   }

--- a/aws-kubeflow-kserve/mlflow-module/README.md
+++ b/aws-kubeflow-kserve/mlflow-module/README.md
@@ -26,7 +26,3 @@ kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingre
 ```
 
 In the output of this command, the EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
-
-
-
-

--- a/aws-kubeflow-kserve/mlflow-module/README.md
+++ b/aws-kubeflow-kserve/mlflow-module/README.md
@@ -17,11 +17,15 @@ Output | Description
 ingress-controller-name | Used for getting the ingress URL for the MLflow tracking server|
 ingress-controller-namespace | Used for getting the ingress URL for the MLflow tracking server|
 
-The folowing command can be used to get the tracking URL for the MLflow server. The EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
+The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
+
+However, you can also manually query the URL by using the folowing command.
 
 ```
-kubectl get service <ingress-controller-name> -n <ingress-controller-namespace>
+kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>
 ```
+
+In the output of this command, the EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
 
 
 

--- a/aws-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/aws-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -5,6 +5,12 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set proxied access to artifact storage
+  set {
+    name  = "artifactRoot.proxiedArtifactStorage"
+    value = var.artifact_Proxied_Access
+  }  
+
   # set values for S3 artifact store
   set {
     name  = "artifactRoot.s3.enabled"

--- a/aws-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/aws-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -5,6 +5,13 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set workload identity annotations for the mlflow 
+  # kubernetes service account
+  set {
+    name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+    value = var.kubernetes_sa
+  }  
+
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"

--- a/aws-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/aws-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -10,13 +10,13 @@ resource "helm_release" "mlflow-tracking" {
   set {
     name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
     value = var.kubernetes_sa
-  }  
+  }
 
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"
     value = var.artifact_Proxied_Access
-  }  
+  }
 
   # set values for S3 artifact store
   set {

--- a/aws-kubeflow-kserve/mlflow-module/variables.tf
+++ b/aws-kubeflow-kserve/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "artifact_Proxied_Access" {
+  type    = bool
+  default = false
+}
+
 variable "artifact_S3" {
   type    = bool
   default = false

--- a/aws-kubeflow-kserve/mlflow-module/variables.tf
+++ b/aws-kubeflow-kserve/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "kubernetes_sa" {
+  type    = string
+  default = ""
+}
+
 variable "artifact_Proxied_Access" {
   type    = bool
   default = false

--- a/aws-kubeflow-kserve/mlflow.tf
+++ b/aws-kubeflow-kserve/mlflow.tf
@@ -6,11 +6,12 @@ module "mlflow" {
   depends_on = [module.eks]
 
   # details about the mlflow deployment
-  htpasswd               = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
-  artifact_S3            = local.mlflow.artifact_S3
-  artifact_S3_Bucket     = local.mlflow.artifact_S3_Bucket == "" ? aws_s3_bucket.zenml-artifact-store.bucket : local.mlflow.artifact_S3_Bucket
-  artifact_S3_Access_Key = var.mlflow-artifact-S3-access-key
-  artifact_S3_Secret_Key = var.mlflow-artifact-S3-secret-key
+  htpasswd                = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
+  artifact_S3             = local.mlflow.artifact_S3
+  artifact_S3_Bucket      = local.mlflow.artifact_S3_Bucket == "" ? aws_s3_bucket.zenml-artifact-store.bucket : local.mlflow.artifact_S3_Bucket
+  artifact_S3_Access_Key  = var.mlflow-artifact-S3-access-key
+  artifact_S3_Secret_Key  = var.mlflow-artifact-S3-secret-key
 
 }
 

--- a/aws-minimal/locals.tf
+++ b/aws-minimal/locals.tf
@@ -20,7 +20,8 @@ locals {
     namespace = "seldon-system"
   }
   mlflow = {
-    artifact_S3 = "true"
+    artifact_Proxied_Access = "false"
+    artifact_S3             = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_S3_Bucket = ""
   }

--- a/aws-minimal/mlflow-module/README.md
+++ b/aws-minimal/mlflow-module/README.md
@@ -17,12 +17,12 @@ Output | Description
 ingress-controller-name | Used for getting the ingress URL for the MLflow tracking server|
 ingress-controller-namespace | Used for getting the ingress URL for the MLflow tracking server|
 
-The folowing command can be used to get the tracking URL for the MLflow server. The EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
+The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
+
+However, you can also manually query the URL by using the folowing command.
 
 ```
-kubectl get service <ingress-controller-name> -n <ingress-controller-namespace>
+kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>
 ```
 
-
-
-
+In the output of this command, the EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.

--- a/aws-minimal/mlflow-module/mlflow.tf
+++ b/aws-minimal/mlflow-module/mlflow.tf
@@ -5,6 +5,12 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set proxied access to artifact storage
+  set {
+    name  = "artifactRoot.proxiedArtifactStorage"
+    value = var.artifact_Proxied_Access
+  }  
+
   # set values for S3 artifact store
   set {
     name  = "artifactRoot.s3.enabled"

--- a/aws-minimal/mlflow-module/mlflow.tf
+++ b/aws-minimal/mlflow-module/mlflow.tf
@@ -5,6 +5,13 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set workload identity annotations for the mlflow 
+  # kubernetes service account
+  set {
+    name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+    value = var.kubernetes_sa
+  }  
+
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"

--- a/aws-minimal/mlflow-module/mlflow.tf
+++ b/aws-minimal/mlflow-module/mlflow.tf
@@ -10,13 +10,13 @@ resource "helm_release" "mlflow-tracking" {
   set {
     name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
     value = var.kubernetes_sa
-  }  
+  }
 
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"
     value = var.artifact_Proxied_Access
-  }  
+  }
 
   # set values for S3 artifact store
   set {

--- a/aws-minimal/mlflow-module/variables.tf
+++ b/aws-minimal/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "artifact_Proxied_Access" {
+  type    = bool
+  default = false
+}
+
 variable "artifact_S3" {
   type    = bool
   default = false

--- a/aws-minimal/mlflow-module/variables.tf
+++ b/aws-minimal/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "kubernetes_sa" {
+  type    = string
+  default = ""
+}
+
 variable "artifact_Proxied_Access" {
   type    = bool
   default = false

--- a/aws-minimal/mlflow.tf
+++ b/aws-minimal/mlflow.tf
@@ -6,11 +6,12 @@ module "mlflow" {
   depends_on = [module.eks]
 
   # details about the mlflow deployment
-  htpasswd               = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
-  artifact_S3            = local.mlflow.artifact_S3
-  artifact_S3_Bucket     = local.mlflow.artifact_S3_Bucket == "" ? aws_s3_bucket.zenml-artifact-store.bucket : local.mlflow.artifact_S3_Bucket
-  artifact_S3_Access_Key = var.mlflow-artifact-S3-access-key
-  artifact_S3_Secret_Key = var.mlflow-artifact-S3-secret-key
+  htpasswd                = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
+  artifact_S3             = local.mlflow.artifact_S3
+  artifact_S3_Bucket      = local.mlflow.artifact_S3_Bucket == "" ? aws_s3_bucket.zenml-artifact-store.bucket : local.mlflow.artifact_S3_Bucket
+  artifact_S3_Access_Key  = var.mlflow-artifact-S3-access-key
+  artifact_S3_Secret_Key  = var.mlflow-artifact-S3-secret-key
 
 }
 

--- a/azure-minimal/locals.tf
+++ b/azure-minimal/locals.tf
@@ -39,6 +39,7 @@ locals {
     namespace = "seldon-system"
   }
   mlflow = {
+    artifact_Proxied_Access = "false"
     artifact_Azure = "true"
     # if not set, the container created as part of the deployment will be used
     artifact_Azure_Storage_Account_Name = ""

--- a/azure-minimal/locals.tf
+++ b/azure-minimal/locals.tf
@@ -40,7 +40,7 @@ locals {
   }
   mlflow = {
     artifact_Proxied_Access = "false"
-    artifact_Azure = "true"
+    artifact_Azure          = "true"
     # if not set, the container created as part of the deployment will be used
     artifact_Azure_Storage_Account_Name = ""
     # this field is considered only when the storage account above is set

--- a/azure-minimal/mlflow-module/README.md
+++ b/azure-minimal/mlflow-module/README.md
@@ -17,12 +17,12 @@ Output | Description
 ingress-controller-name | Used for getting the ingress URL for the MLflow tracking server|
 ingress-controller-namespace | Used for getting the ingress URL for the MLflow tracking server|
 
-The folowing command can be used to get the tracking URL for the MLflow server. The EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
+The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
+
+However, you can also manually query the URL by using the folowing command.
 
 ```
-kubectl get service <ingress-controller-name> -n <ingress-controller-namespace>
+kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>
 ```
 
-
-
-
+In the output of this command, the EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.

--- a/azure-minimal/mlflow-module/mlflow.tf
+++ b/azure-minimal/mlflow-module/mlflow.tf
@@ -5,6 +5,12 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set proxied access to artifact storage
+  set {
+    name  = "artifactRoot.proxiedArtifactStorage"
+    value = var.artifact_Proxied_Access
+  }  
+
   # set values for S3 artifact store
   set {
     name  = "artifactRoot.s3.enabled"

--- a/azure-minimal/mlflow-module/mlflow.tf
+++ b/azure-minimal/mlflow-module/mlflow.tf
@@ -5,6 +5,13 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set workload identity annotations for the mlflow 
+  # kubernetes service account
+  set {
+    name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+    value = var.kubernetes_sa
+  }  
+
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"

--- a/azure-minimal/mlflow-module/mlflow.tf
+++ b/azure-minimal/mlflow-module/mlflow.tf
@@ -10,13 +10,13 @@ resource "helm_release" "mlflow-tracking" {
   set {
     name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
     value = var.kubernetes_sa
-  }  
+  }
 
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"
     value = var.artifact_Proxied_Access
-  }  
+  }
 
   # set values for S3 artifact store
   set {

--- a/azure-minimal/mlflow-module/variables.tf
+++ b/azure-minimal/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "artifact_Proxied_Access" {
+  type    = bool
+  default = false
+}
+
 variable "artifact_S3" {
   type    = bool
   default = false

--- a/azure-minimal/mlflow-module/variables.tf
+++ b/azure-minimal/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "kubernetes_sa" {
+  type    = string
+  default = ""
+}
+
 variable "artifact_Proxied_Access" {
   type    = bool
   default = false

--- a/azure-minimal/mlflow.tf
+++ b/azure-minimal/mlflow.tf
@@ -7,6 +7,7 @@ module "mlflow" {
 
   # details about the mlflow deployment
   htpasswd                            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  artifact_Proxied_Access             = local.mlflow.artifact_Proxied_Access
   artifact_Azure                      = local.mlflow.artifact_Azure
   artifact_Azure_Storage_Account_Name = local.mlflow.artifact_Azure_Storage_Account_Name == "" ? azurerm_storage_account.zenml-account.name : local.mlflow.artifact_Azure_Storage_Account_Name
   artifact_Azure_Container            = local.mlflow.artifact_Azure_Storage_Account_Name == "" ? azurerm_storage_container.artifact-store.name : local.mlflow.artifact_Azure_Container

--- a/azure-minimal/outputs.tf
+++ b/azure-minimal/outputs.tf
@@ -70,7 +70,7 @@ output "seldon-prediction-spec" {
 output "seldon-base-url" {
   value = data.kubernetes_service.seldon_ingress.status.0.load_balancer.0.ingress.0.ip
 }
-  
+
 # output the name of the stack YAML file created
 output "stack-yaml-path" {
   value = local_file.stack_file.filename

--- a/gcp-kubeflow-kserve/configure_kubectl.tf
+++ b/gcp-kubeflow-kserve/configure_kubectl.tf
@@ -1,6 +1,6 @@
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials ${google_container_cluster.gke.name} --region ${local.region} --project ${local.project_id}"
+    command = "gcloud container clusters get-credentials ${module.gke.name} --region ${local.region} --project ${local.project_id}"
   }
 }

--- a/gcp-kubeflow-kserve/gke.tf
+++ b/gcp-kubeflow-kserve/gke.tf
@@ -1,15 +1,59 @@
 data "google_client_config" "default" {}
-resource "google_container_cluster" "gke" {
-  name               = "${local.prefix}-${local.gke.cluster_name}"
-  location           = local.region
-  initial_node_count = 1
+module "gke" {
+  depends_on = [
+    google_project_service.compute_engine_api
+  ]
 
-  node_config {
-    service_account = google_service_account.gke-service-account.email
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
+  source            = "terraform-google-modules/kubernetes-engine/google"
+  project_id        = local.project_id
+  name              = "${local.prefix}-${local.gke.cluster_name}"
+  region            = local.region
+  zones             = ["${local.region}-a", "${local.region}-b", "${local.region}-c"]
+  network           = module.vpc.network_name
+  subnetwork        = module.vpc.subnets_names[0]
+  ip_range_pods     = "gke-pods"
+  ip_range_services = "gke-services"
+
+  http_load_balancing        = false
+  network_policy             = false
+  horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
+
+  node_pools = [
+    {
+      name            = "default-node-pool"
+      machine_type    = "e2-standard-4"
+      node_locations  = "${local.region}-b"
+      min_count       = 1
+      max_count       = 3
+      local_ssd_count = 0
+      disk_size_gb    = 100
+      disk_type       = "pd-standard"
+      image_type      = "COS_CONTAINERD"
+      enable_gcfs     = false
+      auto_repair     = true
+      auto_upgrade    = true
+      service_account = google_service_account.gke-service-account.email
+
+      preemptible        = false
+      initial_node_count = 1
+    },
+  ]
+
+  node_pools_oauth_scopes = {
+    all = []
+
+    default-node-pool = [
+      "https://www.googleapis.com/auth/cloud-platform",
     ]
-    machine_type = "e2-standard-4"
+  }
+
+  node_pools_labels = {
+    all = {}
+
+    default-node-pool = {
+      default-node-pool = true
+    }
   }
 }
 

--- a/gcp-kubeflow-kserve/helm.tf
+++ b/gcp-kubeflow-kserve/helm.tf
@@ -1,8 +1,8 @@
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {
-    host                   = "https://${google_container_cluster.gke.endpoint}"
+    host                   = "https://${module.gke.endpoint}"
     token                  = data.google_client_config.default.access_token
-    cluster_ca_certificate = base64decode(google_container_cluster.gke.master_auth.0.cluster_ca_certificate)
+    cluster_ca_certificate = base64decode(module.gke.ca_certificate)
   }
 }

--- a/gcp-kubeflow-kserve/kserve.tf
+++ b/gcp-kubeflow-kserve/kserve.tf
@@ -5,7 +5,7 @@ module "kserve" {
   workloads_namespace = local.kserve.workloads_namespace
 
   depends_on = [
-    google_container_cluster.gke,
+    module.gke,
     null_resource.configure-local-kubectl,
   ]
 }

--- a/gcp-kubeflow-kserve/kubeflow.tf
+++ b/gcp-kubeflow-kserve/kubeflow.tf
@@ -28,6 +28,6 @@ resource "null_resource" "kubeflow" {
 
   depends_on = [
     null_resource.configure-local-kubectl,
-    google_container_cluster.gke,
+    module.gke,
   ]
 }

--- a/gcp-kubeflow-kserve/kubernetes.tf
+++ b/gcp-kubeflow-kserve/kubernetes.tf
@@ -1,13 +1,13 @@
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {
-  host                   = "https://${google_container_cluster.gke.endpoint}"
+  host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = base64decode(google_container_cluster.gke.master_auth.0.cluster_ca_certificate)
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
 provider "kubectl" {
-  host                   = "https://${google_container_cluster.gke.endpoint}"
+  host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = base64decode(google_container_cluster.gke.master_auth.0.cluster_ca_certificate)
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }

--- a/gcp-kubeflow-kserve/locals.tf
+++ b/gcp-kubeflow-kserve/locals.tf
@@ -1,6 +1,6 @@
 # config values to use across the module
 locals {
-  prefix     = "demo"
+  prefix = "demo"
 
   # if you're using europe-west1, please make the following modification in
   # the gke.tf file:
@@ -40,7 +40,7 @@ locals {
 
   mlflow = {
     artifact_Proxied_Access = "false"
-    artifact_GCS = "true"
+    artifact_GCS            = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_GCS_Bucket = ""
   }

--- a/gcp-kubeflow-kserve/locals.tf
+++ b/gcp-kubeflow-kserve/locals.tf
@@ -39,6 +39,7 @@ locals {
   }
 
   mlflow = {
+    artifact_Proxied_Access = "false"
     artifact_GCS = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_GCS_Bucket = ""

--- a/gcp-kubeflow-kserve/mlflow-module/README.md
+++ b/gcp-kubeflow-kserve/mlflow-module/README.md
@@ -17,12 +17,12 @@ Output | Description
 ingress-controller-name | Used for getting the ingress URL for the MLflow tracking server|
 ingress-controller-namespace | Used for getting the ingress URL for the MLflow tracking server|
 
-The folowing command can be used to get the tracking URL for the MLflow server. The EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
+The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
+
+However, you can also manually query the URL by using the folowing command.
 
 ```
-kubectl get service <ingress-controller-name> -n <ingress-controller-namespace>
+kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>
 ```
 
-
-
-
+In the output of this command, the EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.

--- a/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -5,6 +5,12 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set proxied access to artifact storage
+  set {
+    name  = "artifactRoot.proxiedArtifactStorage"
+    value = var.artifact_Proxied_Access
+  }  
+
   # set values for S3 artifact store
   set {
     name  = "artifactRoot.s3.enabled"

--- a/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -5,6 +5,13 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set workload identity annotations for the mlflow 
+  # kubernetes service account
+  set {
+    name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+    value = var.kubernetes_sa
+  }  
+
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"

--- a/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -10,13 +10,13 @@ resource "helm_release" "mlflow-tracking" {
   set {
     name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
     value = var.kubernetes_sa
-  }  
+  }
 
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"
     value = var.artifact_Proxied_Access
-  }  
+  }
 
   # set values for S3 artifact store
   set {

--- a/gcp-kubeflow-kserve/mlflow-module/variables.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "artifact_Proxied_Access" {
+  type    = bool
+  default = false
+}
+
 variable "artifact_S3" {
   type    = bool
   default = false

--- a/gcp-kubeflow-kserve/mlflow-module/variables.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "kubernetes_sa" {
+  type    = string
+  default = ""
+}
+
 variable "artifact_Proxied_Access" {
   type    = bool
   default = false

--- a/gcp-kubeflow-kserve/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow.tf
@@ -6,10 +6,10 @@ module "mlflow" {
   depends_on = [module.gke]
 
   # details about the mlflow deployment
-  htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  htpasswd                = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
   artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
-  artifact_GCS        = local.mlflow.artifact_GCS
-  artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
+  artifact_GCS            = local.mlflow.artifact_GCS
+  artifact_GCS_Bucket     = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
 
   # set workload identity annotations for mlflow kubernetes sa
   kubernetes_sa = google_service_account.gke-service-account.email

--- a/gcp-kubeflow-kserve/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow.tf
@@ -7,6 +7,7 @@ module "mlflow" {
 
   # details about the mlflow deployment
   htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
   artifact_GCS        = local.mlflow.artifact_GCS
   artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
 }

--- a/gcp-kubeflow-kserve/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow.tf
@@ -3,15 +3,29 @@ module "mlflow" {
   source = "./mlflow-module"
 
   # run only after the eks cluster is set up
-  depends_on = [google_container_cluster.gke]
+  depends_on = [module.gke]
 
   # details about the mlflow deployment
   htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
   artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
   artifact_GCS        = local.mlflow.artifact_GCS
   artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
+
+  # set workload identity annotations for mlflow kubernetes sa
+  kubernetes_sa = google_service_account.gke-service-account.email
 }
 
 resource "htpasswd_password" "hash" {
   password = var.mlflow-password
+}
+
+# allow the mlflow kubernetes sa to access GKE's IAM role
+# the GKE IAM role should have access to Storage resources
+resource "google_service_account_iam_member" "mlflow-storage-access" {
+  service_account_id = google_service_account.gke-service-account.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[default/mlflow-tracking]"
+  depends_on = [
+    module.mlflow
+  ]
 }

--- a/gcp-kubeflow-kserve/output_file.tf
+++ b/gcp-kubeflow-kserve/output_file.tf
@@ -27,7 +27,7 @@ resource "local_file" "stack_file" {
         flavor: kubeflow
         name: gke_kubeflow_orchestrator
         synchronous: True
-        kubernetes_context: gke_${local.project_id}_${local.region}_${google_container_cluster.gke.name}
+        kubernetes_context: gke_${local.project_id}_${local.region}_${module.gke.name}
       secrets_manager:
         flavor: gcp_secrets_manager
         name: gcp_secrets_manager
@@ -41,7 +41,7 @@ resource "local_file" "stack_file" {
       model_deployer:
         flavor: kserve
         name: gke_kserve
-        kubernetes_context: gke_${local.project_id}_${local.region}_${google_container_cluster.gke.name}
+        kubernetes_context: gke_${local.project_id}_${local.region}_${module.gke.name}
         kubernetes_namespace: ${local.kserve.workloads_namespace}
         base_url: http://${data.kubernetes_service.kserve_ingress.status.0.load_balancer.0.ingress.0.ip}:${data.kubernetes_service.kserve_ingress.spec.0.port.1.port}
         secret: gcp_kserve_secret

--- a/gcp-kubeflow-kserve/outputs.tf
+++ b/gcp-kubeflow-kserve/outputs.tf
@@ -1,6 +1,6 @@
 # output for the GKE cluster
 output "gke-cluster-name" {
-  value = google_container_cluster.gke.name
+  value = module.gke.name
 }
 
 # output for the GCS bucket

--- a/gcp-minimal/configure_kubectl.tf
+++ b/gcp-minimal/configure_kubectl.tf
@@ -1,6 +1,6 @@
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials ${google_container_cluster.gke.name} --region ${local.region} --project ${local.project_id}"
+    command = "gcloud container clusters get-credentials ${module.gke.name} --region ${local.region} --project ${local.project_id}"
   }
 }

--- a/gcp-minimal/gke.tf
+++ b/gcp-minimal/gke.tf
@@ -1,15 +1,59 @@
 data "google_client_config" "default" {}
-resource "google_container_cluster" "gke" {
-  name               = "${local.prefix}-${local.gke.cluster_name}"
-  location           = local.region
-  initial_node_count = 1
+module "gke" {
+  depends_on = [
+    google_project_service.compute_engine_api
+  ]
 
-  node_config {
-    service_account = google_service_account.gke-service-account.email
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
+  source            = "terraform-google-modules/kubernetes-engine/google"
+  project_id        = local.project_id
+  name              = "${local.prefix}-${local.gke.cluster_name}"
+  region            = local.region
+  zones             = ["${local.region}-a", "${local.region}-b", "${local.region}-c"]
+  network           = module.vpc.network_name
+  subnetwork        = module.vpc.subnets_names[0]
+  ip_range_pods     = "gke-pods"
+  ip_range_services = "gke-services"
+
+  http_load_balancing        = false
+  network_policy             = false
+  horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
+
+  node_pools = [
+    {
+      name            = "default-node-pool"
+      machine_type    = "e2-medium"
+      node_locations  = "${local.region}-b"
+      min_count       = 1
+      max_count       = 3
+      local_ssd_count = 0
+      disk_size_gb    = 100
+      disk_type       = "pd-standard"
+      image_type      = "COS_CONTAINERD"
+      enable_gcfs     = false
+      auto_repair     = true
+      auto_upgrade    = true
+      service_account = google_service_account.gke-service-account.email
+
+      preemptible        = false
+      initial_node_count = 1
+    },
+  ]
+
+  node_pools_oauth_scopes = {
+    all = []
+
+    default-node-pool = [
+      "https://www.googleapis.com/auth/cloud-platform",
     ]
-    machine_type = "e2-medium"
+  }
+
+  node_pools_labels = {
+    all = {}
+
+    default-node-pool = {
+      default-node-pool = true
+    }
   }
 }
 

--- a/gcp-minimal/helm.tf
+++ b/gcp-minimal/helm.tf
@@ -1,8 +1,8 @@
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {
-    host                   = "https://${google_container_cluster.gke.endpoint}"
+    host                   = "https://${module.gke.endpoint}"
     token                  = data.google_client_config.default.access_token
-    cluster_ca_certificate = base64decode(google_container_cluster.gke.master_auth.0.cluster_ca_certificate)
+    cluster_ca_certificate = base64decode(module.gke.ca_certificate)
   }
 }

--- a/gcp-minimal/kubernetes.tf
+++ b/gcp-minimal/kubernetes.tf
@@ -1,13 +1,13 @@
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {
-  host                   = "https://${google_container_cluster.gke.endpoint}"
+  host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = base64decode(google_container_cluster.gke.master_auth.0.cluster_ca_certificate)
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
 provider "kubectl" {
-  host                   = "https://${google_container_cluster.gke.endpoint}"
+  host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = base64decode(google_container_cluster.gke.master_auth.0.cluster_ca_certificate)
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }

--- a/gcp-minimal/locals.tf
+++ b/gcp-minimal/locals.tf
@@ -30,7 +30,7 @@ locals {
   }
   mlflow = {
     artifact_Proxied_Access = "false"
-    artifact_GCS = "true"
+    artifact_GCS            = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_GCS_Bucket = ""
   }

--- a/gcp-minimal/locals.tf
+++ b/gcp-minimal/locals.tf
@@ -29,6 +29,7 @@ locals {
     namespace = "seldon-system"
   }
   mlflow = {
+    artifact_Proxied_Access = "false"
     artifact_GCS = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_GCS_Bucket = ""

--- a/gcp-minimal/mlflow-module/README.md
+++ b/gcp-minimal/mlflow-module/README.md
@@ -17,12 +17,12 @@ Output | Description
 ingress-controller-name | Used for getting the ingress URL for the MLflow tracking server|
 ingress-controller-namespace | Used for getting the ingress URL for the MLflow tracking server|
 
-The folowing command can be used to get the tracking URL for the MLflow server. The EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
+The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
+
+However, you can also manually query the URL by using the folowing command.
 
 ```
-kubectl get service <ingress-controller-name> -n <ingress-controller-namespace>
+kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>
 ```
 
-
-
-
+In the output of this command, the EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.

--- a/gcp-minimal/mlflow-module/mlflow.tf
+++ b/gcp-minimal/mlflow-module/mlflow.tf
@@ -5,6 +5,12 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set proxied access to artifact storage
+  set {
+    name  = "artifactRoot.proxiedArtifactStorage"
+    value = var.artifact_Proxied_Access
+  }  
+
   # set values for S3 artifact store
   set {
     name  = "artifactRoot.s3.enabled"

--- a/gcp-minimal/mlflow-module/mlflow.tf
+++ b/gcp-minimal/mlflow-module/mlflow.tf
@@ -5,6 +5,13 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set workload identity annotations for the mlflow 
+  # kubernetes service account
+  set {
+    name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+    value = var.kubernetes_sa
+  }  
+
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"

--- a/gcp-minimal/mlflow-module/mlflow.tf
+++ b/gcp-minimal/mlflow-module/mlflow.tf
@@ -10,13 +10,13 @@ resource "helm_release" "mlflow-tracking" {
   set {
     name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
     value = var.kubernetes_sa
-  }  
+  }
 
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"
     value = var.artifact_Proxied_Access
-  }  
+  }
 
   # set values for S3 artifact store
   set {

--- a/gcp-minimal/mlflow-module/variables.tf
+++ b/gcp-minimal/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "artifact_Proxied_Access" {
+  type    = bool
+  default = false
+}
+
 variable "artifact_S3" {
   type    = bool
   default = false

--- a/gcp-minimal/mlflow-module/variables.tf
+++ b/gcp-minimal/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "kubernetes_sa" {
+  type    = string
+  default = ""
+}
+
 variable "artifact_Proxied_Access" {
   type    = bool
   default = false

--- a/gcp-minimal/mlflow.tf
+++ b/gcp-minimal/mlflow.tf
@@ -3,15 +3,29 @@ module "mlflow" {
   source = "./mlflow-module"
 
   # run only after the eks cluster is set up
-  depends_on = [google_container_cluster.gke]
+  depends_on = [module.gke]
 
   # details about the mlflow deployment
   htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
   artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
   artifact_GCS        = local.mlflow.artifact_GCS
   artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
+  
+  # set workload identity annotations for mlflow kubernetes sa
+  kubernetes_sa = google_service_account.gke-service-account.email
 }
 
 resource "htpasswd_password" "hash" {
   password = var.mlflow-password
+}
+
+# allow the mlflow kubernetes sa to access GKE's IAM role
+# the GKE IAM role should have access to Storage resources
+resource "google_service_account_iam_member" "mlflow-storage-access" {
+  service_account_id = google_service_account.gke-service-account.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[default/mlflow-tracking]"
+  depends_on = [
+    module.mlflow
+  ]
 }

--- a/gcp-minimal/mlflow.tf
+++ b/gcp-minimal/mlflow.tf
@@ -7,6 +7,7 @@ module "mlflow" {
 
   # details about the mlflow deployment
   htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
   artifact_GCS        = local.mlflow.artifact_GCS
   artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
 }

--- a/gcp-minimal/mlflow.tf
+++ b/gcp-minimal/mlflow.tf
@@ -6,11 +6,11 @@ module "mlflow" {
   depends_on = [module.gke]
 
   # details about the mlflow deployment
-  htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  htpasswd                = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
   artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
-  artifact_GCS        = local.mlflow.artifact_GCS
-  artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
-  
+  artifact_GCS            = local.mlflow.artifact_GCS
+  artifact_GCS_Bucket     = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
+
   # set workload identity annotations for mlflow kubernetes sa
   kubernetes_sa = google_service_account.gke-service-account.email
 }

--- a/gcp-minimal/output_file.tf
+++ b/gcp-minimal/output_file.tf
@@ -27,7 +27,7 @@ resource "local_file" "stack_file" {
         flavor: kubernetes
         name: gke_kubernetes_orchestrator
         synchronous: True
-        kubernetes_context: gke_${local.project_id}_${local.region}_${google_container_cluster.gke.name}
+        kubernetes_context: gke_${local.project_id}_${local.region}_${module.gke.name}
       secrets_manager:
         flavor: gcp_secrets_manager
         name: gcp_secrets_manager
@@ -41,7 +41,7 @@ resource "local_file" "stack_file" {
       model_deployer:
         flavor: seldon
         name: gke_seldon_model_deployer
-        kubernetes_context: gke_${local.project_id}_${local.region}_${google_container_cluster.gke.name}
+        kubernetes_context: gke_${local.project_id}_${local.region}_${module.gke.name}
         kubernetes_namespace: ${kubernetes_namespace.seldon-workloads.metadata[0].name}
         base_url: ${data.kubernetes_service.seldon_ingress.status.0.load_balancer.0.ingress.0.ip}
         secret: gcp_seldon_secret

--- a/gcp-minimal/outputs.tf
+++ b/gcp-minimal/outputs.tf
@@ -1,6 +1,6 @@
 # output for the GKE cluster
 output "gke-cluster-name" {
-  value = google_container_cluster.gke.name
+  value = module.gke.name
 }
 
 # output for the GCS bucket

--- a/gcp-minimal/seldon.tf
+++ b/gcp-minimal/seldon.tf
@@ -4,16 +4,16 @@ module "seldon" {
   source = "./seldon"
 
   # run only after the eks cluster is set up
-  depends_on = [google_container_cluster.gke]
+  depends_on = [module.gke]
 
   # details about the seldon deployment
   seldon_name      = local.seldon.name
   seldon_namespace = local.seldon.namespace
 
   # details about the cluster
-  cluster_endpoint       = "https://${google_container_cluster.gke.endpoint}"
-  cluster_ca_certificate = base64decode(google_container_cluster.gke.master_auth.0.cluster_ca_certificate)
-  cluster_token          = data.google_client_config.default.access_token
+  cluster_endpoint       = "https://${module.gke.endpoint}"
+  cluster_ca_certificate = data.google_client_config.default.access_token
+  cluster_token          = base64decode(module.gke.ca_certificate)
 }
 
 resource "kubernetes_namespace" "seldon-workloads" {

--- a/vertex-ai/locals.tf
+++ b/vertex-ai/locals.tf
@@ -54,6 +54,7 @@ locals {
   }
 
   mlflow = {
+    artifact_Proxied_Access = "false"
     artifact_GCS = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_GCS_Bucket = ""

--- a/vertex-ai/locals.tf
+++ b/vertex-ai/locals.tf
@@ -55,7 +55,7 @@ locals {
 
   mlflow = {
     artifact_Proxied_Access = "false"
-    artifact_GCS = "true"
+    artifact_GCS            = "true"
     # if not set, the bucket created as part of the deployment will be used
     artifact_GCS_Bucket = ""
   }

--- a/vertex-ai/mlflow-module/README.md
+++ b/vertex-ai/mlflow-module/README.md
@@ -17,12 +17,12 @@ Output | Description
 ingress-controller-name | Used for getting the ingress URL for the MLflow tracking server|
 ingress-controller-namespace | Used for getting the ingress URL for the MLflow tracking server|
 
-The folowing command can be used to get the tracking URL for the MLflow server. The EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.
+The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
+
+However, you can also manually query the URL by using the folowing command.
 
 ```
-kubectl get service <ingress-controller-name> -n <ingress-controller-namespace>
+kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>
 ```
 
-
-
-
+In the output of this command, the EXTERNAL_IP field is the IP of the ingress controller and the path "/" is configured already to direct to the MLflow tracking server.

--- a/vertex-ai/mlflow-module/mlflow.tf
+++ b/vertex-ai/mlflow-module/mlflow.tf
@@ -5,6 +5,12 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set proxied access to artifact storage
+  set {
+    name  = "artifactRoot.proxiedArtifactStorage"
+    value = var.artifact_Proxied_Access
+  }  
+
   # set values for S3 artifact store
   set {
     name  = "artifactRoot.s3.enabled"

--- a/vertex-ai/mlflow-module/mlflow.tf
+++ b/vertex-ai/mlflow-module/mlflow.tf
@@ -5,6 +5,13 @@ resource "helm_release" "mlflow-tracking" {
   repository = "https://community-charts.github.io/helm-charts"
   chart      = "mlflow"
 
+  # set workload identity annotations for the mlflow 
+  # kubernetes service account
+  set {
+    name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+    value = var.kubernetes_sa
+  }  
+
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"

--- a/vertex-ai/mlflow-module/mlflow.tf
+++ b/vertex-ai/mlflow-module/mlflow.tf
@@ -10,13 +10,13 @@ resource "helm_release" "mlflow-tracking" {
   set {
     name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
     value = var.kubernetes_sa
-  }  
+  }
 
   # set proxied access to artifact storage
   set {
     name  = "artifactRoot.proxiedArtifactStorage"
     value = var.artifact_Proxied_Access
-  }  
+  }
 
   # set values for S3 artifact store
   set {

--- a/vertex-ai/mlflow-module/variables.tf
+++ b/vertex-ai/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "artifact_Proxied_Access" {
+  type    = bool
+  default = false
+}
+
 variable "artifact_S3" {
   type    = bool
   default = false

--- a/vertex-ai/mlflow-module/variables.tf
+++ b/vertex-ai/mlflow-module/variables.tf
@@ -1,5 +1,10 @@
 variable "htpasswd" {}
 
+variable "kubernetes_sa" {
+  type    = string
+  default = ""
+}
+
 variable "artifact_Proxied_Access" {
   type    = bool
   default = false

--- a/vertex-ai/mlflow.tf
+++ b/vertex-ai/mlflow.tf
@@ -8,6 +8,7 @@ module "mlflow" {
 
   # details about the mlflow deployment
   htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
   artifact_GCS        = local.mlflow.artifact_GCS
   artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
 }

--- a/vertex-ai/mlflow.tf
+++ b/vertex-ai/mlflow.tf
@@ -7,11 +7,11 @@ module "mlflow" {
   count      = local.enable_mlflow ? 1 : 0
 
   # details about the mlflow deployment
-  htpasswd            = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
+  htpasswd                = "${var.mlflow-username}:${htpasswd_password.hash.apr1}"
   artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
-  artifact_GCS        = local.mlflow.artifact_GCS
-  artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
-  
+  artifact_GCS            = local.mlflow.artifact_GCS
+  artifact_GCS_Bucket     = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
+
   # set workload identity annotations for mlflow kubernetes sa
   kubernetes_sa = google_service_account.gke-service-account.email
 }

--- a/vertex-ai/mlflow.tf
+++ b/vertex-ai/mlflow.tf
@@ -26,4 +26,7 @@ resource "google_service_account_iam_member" "mlflow-storage-access" {
   service_account_id = google_service_account.gke-service-account.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${local.project_id}.svc.id.goog[default/mlflow-tracking]"
+  depends_on = [
+    module.mlflow
+  ]
 }

--- a/vertex-ai/mlflow.tf
+++ b/vertex-ai/mlflow.tf
@@ -11,8 +11,19 @@ module "mlflow" {
   artifact_Proxied_Access = local.mlflow.artifact_Proxied_Access
   artifact_GCS        = local.mlflow.artifact_GCS
   artifact_GCS_Bucket = local.mlflow.artifact_GCS_Bucket == "" ? google_storage_bucket.artifact-store.name : local.mlflow.artifact_GCS_Bucket
+  
+  # set workload identity annotations for mlflow kubernetes sa
+  kubernetes_sa = google_service_account.gke-service-account.email
 }
 
 resource "htpasswd_password" "hash" {
   password = var.mlflow-password
+}
+
+# allow the mlflow kubernetes sa to access GKE's IAM role
+# the GKE IAM role should have access to Storage resources
+resource "google_service_account_iam_member" "mlflow-storage-access" {
+  service_account_id = google_service_account.gke-service-account.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[default/mlflow-tracking]"
 }


### PR DESCRIPTION
- The mlflow module now supports the scenario 5. This can be achieved by putting the `artifact_Proxied_Access` variable in the locals file to true.
- MLflow pods on GKE now use Workload identity to enable the `mlflow-tracking` kubernetes service account to use the `Terraform GKE SA` service account to access the Cloud Storage.
- The `gcp-minimal` and gcp-kubeflow-kserve` have reverted to using the `gke` module instead of the `google_container_cluster` resource.
- The `README` is now updated.