### PR TITLE
make enable a variable instead of local

### DIFF
--- a/aws-modular/istio.tf
+++ b/aws-modular/istio.tf
@@ -2,7 +2,7 @@
 module "istio" {
   source = "../modules/istio-module"
 
-  count = (local.kserve.enable || local.seldon.enable) ? 1 : 0
+  count = (var.enable_kserve || var.enable_seldon) ? 1 : 0
 
   depends_on = [
     module.eks,

--- a/aws-modular/kserve.tf
+++ b/aws-modular/kserve.tf
@@ -2,7 +2,7 @@
 module "kserve" {
   source = "../modules/kserve-module"
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   depends_on = [
     module.eks,
@@ -19,7 +19,7 @@ module "kserve" {
 # the namespace where zenml will deploy kserve models
 resource "kubernetes_namespace" "kserve-workloads" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   metadata {
     name = local.kserve.workloads_namespace
@@ -37,7 +37,7 @@ resource "kubernetes_namespace" "kserve-workloads" {
 # it will deploy models
 resource "kubernetes_cluster_role_v1" "kserve" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   metadata {
     name = "kserve-workloads"
@@ -60,7 +60,7 @@ resource "kubernetes_cluster_role_v1" "kserve" {
 # assign role to kubeflow pipeline runner
 resource "kubernetes_role_binding_v1" "kubeflow-kserve" {
 
-  count =  (local.kserve.enable && local.kubeflow.enable) ? 1 : 0
+  count =  (var.enable_kserve && var.enable_kubeflow) ? 1 : 0
 
   metadata {
     name = "kubeflow-kserve"
@@ -87,7 +87,7 @@ resource "kubernetes_role_binding_v1" "kubeflow-kserve" {
 # assign role to kubernetes pipeline runner
 resource "kubernetes_role_binding_v1" "k8s-kserve" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   metadata {
     name = "k8s-kserve"

--- a/aws-modular/kserve.tf
+++ b/aws-modular/kserve.tf
@@ -12,8 +12,8 @@ module "kserve" {
   ]
 
   knative_version = local.kserve.knative_version
-  kserve_version = local.kserve.version
-  kserve_domain = local.kserve.ingress_host
+  kserve_version  = local.kserve.version
+  kserve_domain   = local.kserve.ingress_host
 }
 
 # the namespace where zenml will deploy kserve models
@@ -60,10 +60,10 @@ resource "kubernetes_cluster_role_v1" "kserve" {
 # assign role to kubeflow pipeline runner
 resource "kubernetes_role_binding_v1" "kubeflow-kserve" {
 
-  count =  (var.enable_kserve && var.enable_kubeflow) ? 1 : 0
+  count = (var.enable_kserve && var.enable_kubeflow) ? 1 : 0
 
   metadata {
-    name = "kubeflow-kserve"
+    name      = "kubeflow-kserve"
     namespace = kubernetes_namespace.kserve-workloads[0].metadata[0].name
   }
   role_ref {
@@ -90,7 +90,7 @@ resource "kubernetes_role_binding_v1" "k8s-kserve" {
   count = var.enable_kserve ? 1 : 0
 
   metadata {
-    name = "k8s-kserve"
+    name      = "k8s-kserve"
     namespace = kubernetes_namespace.kserve-workloads[0].metadata[0].name
   }
   role_ref {

--- a/aws-modular/kubeflow.tf
+++ b/aws-modular/kubeflow.tf
@@ -2,7 +2,7 @@
 module "kubeflow-pipelines" {
   source = "../modules/kubeflow-pipelines-module"
 
-  count = local.kubeflow.enable ? 1 : 0
+  count = var.enable_kubeflow ? 1 : 0
 
   # run only after the eks cluster is set up and cert-manager and nginx-ingress
   # are installed 

--- a/aws-modular/kubeflow.tf
+++ b/aws-modular/kubeflow.tf
@@ -14,5 +14,5 @@ module "kubeflow-pipelines" {
   ]
 
   pipeline_version = local.kubeflow.version
-  ingress_host = local.kubeflow.ingress_host
+  ingress_host     = local.kubeflow.ingress_host
 }

--- a/aws-modular/locals.tf
+++ b/aws-modular/locals.tf
@@ -70,6 +70,7 @@ locals {
   }
 
   zenml = {
+    version                 = ""
     database_ssl_ca         = ""
     database_ssl_cert       = ""
     database_ssl_key        = ""

--- a/aws-modular/locals.tf
+++ b/aws-modular/locals.tf
@@ -5,7 +5,7 @@ locals {
   eks = {
     cluster_name = "mycluster"
     # important to use 1.22 or above due to a bug with Istio in older versions
-    cluster_version = "1.22"
+    cluster_version     = "1.22"
     workloads_namespace = "zenml-workloads-k8s"
   }
   vpc = {
@@ -33,7 +33,7 @@ locals {
   }
 
   kubeflow = {
-    version             = "1.8.3"
+    version      = "1.8.3"
     ingress_host = "kubeflow.example.com"
   }
 
@@ -41,7 +41,7 @@ locals {
     version             = "0.40.2"
     dashboard_version   = "0.31.0"
     ingress_host        = "tekton..example.com"
-    workloads_namespace  = "zenml-workloads-tekton"
+    workloads_namespace = "zenml-workloads-tekton"
   }
 
   mlflow = {
@@ -49,12 +49,12 @@ locals {
     artifact_Proxied_Access = "false"
     artifact_S3             = "true"
     # if not set, the bucket created as part of the deployment will be used
-    artifact_S3_Bucket      = ""
-    ingress_host            = "mlflow.example.com"
+    artifact_S3_Bucket = ""
+    ingress_host       = "mlflow.example.com"
   }
 
   kserve = {
-    version              = "0.9.0" 
+    version              = "0.9.0"
     knative_version      = "1.0.0"
     workloads_namespace  = "zenml-workloads-kserve"
     service_account_name = "kserve"
@@ -70,14 +70,14 @@ locals {
   }
 
   zenml = {
-    version                 = ""
-    database_ssl_ca         = ""
-    database_ssl_cert       = ""
-    database_ssl_key        = ""
-    database_ssl_verify_server_cert = false  
-    ingress_host            = "zenml.example.com"
-    ingress_tls             = true
-    image_tag               = ""
+    version                         = ""
+    database_ssl_ca                 = ""
+    database_ssl_cert               = ""
+    database_ssl_key                = ""
+    database_ssl_verify_server_cert = false
+    ingress_host                    = "zenml.example.com"
+    ingress_tls                     = true
+    image_tag                       = ""
   }
 
   tags = {

--- a/aws-modular/locals.tf
+++ b/aws-modular/locals.tf
@@ -33,13 +33,11 @@ locals {
   }
 
   kubeflow = {
-    enable              = true
     version             = "1.8.3"
     ingress_host = "kubeflow.example.com"
   }
 
   tekton = {
-    enable              = true
     version             = "0.40.2"
     dashboard_version   = "0.31.0"
     ingress_host        = "tekton..example.com"
@@ -47,7 +45,6 @@ locals {
   }
 
   mlflow = {
-    enable                  = true
     version                 = "0.7.13"
     artifact_Proxied_Access = "false"
     artifact_S3             = "true"
@@ -57,7 +54,6 @@ locals {
   }
 
   kserve = {
-    enable               = true
     version              = "0.9.0" 
     knative_version      = "1.0.0"
     workloads_namespace  = "zenml-workloads-kserve"
@@ -66,7 +62,6 @@ locals {
   }
 
   seldon = {
-    enable               = true
     version              = "1.15.0"
     name                 = "seldon"
     namespace            = "seldon-system"
@@ -75,7 +70,6 @@ locals {
   }
 
   zenml = {
-    enable                  = true
     database_ssl_ca         = ""
     database_ssl_cert       = ""
     database_ssl_key        = ""

--- a/aws-modular/mlflow.tf
+++ b/aws-modular/mlflow.tf
@@ -2,7 +2,7 @@
 module "mlflow" {
   source = "../modules/mlflow-module"
 
-  count = local.mlflow.enable ? 1 : 0
+  count = var.enable_mlflow ? 1 : 0
 
   # run only after the eks cluster, cert-manager and nginx-ingress are set up
   depends_on = [

--- a/aws-modular/nginx_ingress.tf
+++ b/aws-modular/nginx_ingress.tf
@@ -2,7 +2,7 @@
 module "nginx-ingress" {
   source = "../modules/nginx-ingress-module"
 
-  count = (local.mlflow.enable || local.kubeflow.enable || local.zenml.enable || local.tekton.enable) ? 1 : 0
+  count = (var.enable_mlflow || var.enable_kubeflow || var.enable_zenml || var.enable_tekton) ? 1 : 0
 
   # run only after the gke cluster is set up
   depends_on = [

--- a/aws-modular/output_file.tf
+++ b/aws-modular/output_file.tf
@@ -31,12 +31,12 @@ resource "local_file" "stack_file" {
         id: ${uuid()}
         flavor: mlflow
         name: eks_mlflow_experiment_tracker
-        configuration: {"tracking_uri": "${local.mlflow.enable ? module.mlflow[0].mlflow-tracking-URL : ""}", "tracking_username": "${var.mlflow-username}", "tracking_password": "${var.mlflow-password}"}
+        configuration: {"tracking_uri": "${var.enable_mlflow ? module.mlflow[0].mlflow-tracking-URL : ""}", "tracking_username": "${var.mlflow-username}", "tracking_password": "${var.mlflow-password}"}
       model_deployer:
         id: ${uuid()}
         flavor: kserve
         name: eks_kserve_model_deployer
-        configuration: {"kubernetes_context": "terraform", "kubernetes_namespace": "${local.kserve.workloads_namespace}", "base_url": "${local.kserve.enable ? module.kserve[0].kserve-base-URL : ""}", "secret": "aws_kserve_secret"}
+        configuration: {"kubernetes_context": "terraform", "kubernetes_namespace": "${local.kserve.workloads_namespace}", "base_url": "${var.enable_kserve ? module.kserve[0].kserve-base-URL : ""}", "secret": "aws_kserve_secret"}
     ADD
   filename = "./aws_kflow_stack_${replace(substr(timestamp(), 0, 16), ":", "_")}.yaml"
 }

--- a/aws-modular/outputs.tf
+++ b/aws-modular/outputs.tf
@@ -30,35 +30,35 @@ output "istio-ingress-hostname" {
 
 
 output "kubeflow-pipelines-ui-URL" {
-  value = local.kubeflow.enable ? module.kubeflow-pipelines[0].pipelines-ui-URL : null
+  value = var.enable_kubeflow ? module.kubeflow-pipelines[0].pipelines-ui-URL : null
 }
 
 output "tekton-pipelines-ui-URL" {
-  value = local.tekton.enable ? module.tekton-pipelines[0].pipelines-ui-URL : null
+  value = var.enable_tekton ? module.tekton-pipelines[0].pipelines-ui-URL : null
 }
 
 # outputs for the MLflow tracking server
 output "mlflow-tracking-URL" {
-  value = local.mlflow.enable ? module.mlflow[0].mlflow-tracking-URL : null
+  value = var.enable_mlflow ? module.mlflow[0].mlflow-tracking-URL : null
 }
 
 # output for kserve model deployer
 output "kserve-workload-namespace" {
-  value       = local.kserve.enable ? local.kserve.workloads_namespace : null
+  value       = var.enable_kserve ? local.kserve.workloads_namespace : null
   description = "The namespace created for hosting your Kserve workloads"
 }
 output "kserve-base-url" {
-  value = local.kserve.enable ? module.kserve[0].kserve-base-URL : null
+  value = var.enable_kserve ? module.kserve[0].kserve-base-URL : null
 }
 
 # output for seldon model deployer
 output "seldon-workload-namespace" {
-  value       = local.seldon.enable ? local.seldon.workloads_namespace : null
+  value       = var.enable_seldon ? local.seldon.workloads_namespace : null
   description = "The namespace created for hosting your Seldon workloads"
 }
 
 output "seldon-base-url" {
-  value = local.seldon.enable ? "http://${module.istio[0].ingress-hostname}:${module.istio[0].ingress-port}" : null
+  value = var.enable_seldon ? "http://${module.istio[0].ingress-hostname}:${module.istio[0].ingress-port}" : null
 }
 
 # output the name of the stack YAML file created
@@ -68,8 +68,8 @@ output "stack-yaml-path" {
 
 # outputs for the ZenML server
 output "zenml-url" {
-  value = local.zenml.enable ? module.zenml[0].zenml_server_url : null
+  value = var.enable_zenml ? module.zenml[0].zenml_server_url : null
 }
 output "zenml-username" {
-  value = local.zenml.enable ? module.zenml[0].username : null
+  value = var.enable_zenml ? module.zenml[0].username : null
 }

--- a/aws-modular/seldon.tf
+++ b/aws-modular/seldon.tf
@@ -3,7 +3,7 @@
 module "seldon" {
   source = "../modules/seldon-module"
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   # run only after the eks cluster and istio are set up
   depends_on = [
@@ -19,7 +19,7 @@ module "seldon" {
 # the namespace where zenml will deploy seldon models
 resource "kubernetes_namespace" "seldon-workloads" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   metadata {
     name = local.seldon.workloads_namespace
@@ -33,7 +33,7 @@ resource "kubernetes_namespace" "seldon-workloads" {
 # will deploy models
 resource "kubernetes_cluster_role_v1" "seldon" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   metadata {
     name = "seldon-workloads"
@@ -56,7 +56,7 @@ resource "kubernetes_cluster_role_v1" "seldon" {
 # assign role to kubeflow pipeline runner
 resource "kubernetes_role_binding_v1" "kubeflow-seldon" {
 
-  count = (local.kubeflow.enable && local.seldon.enable) ? 1 : 0
+  count = (var.enable_kubeflow && var.enable_seldon) ? 1 : 0
 
   metadata {
     name = "kubeflow-seldon"
@@ -81,7 +81,7 @@ resource "kubernetes_role_binding_v1" "kubeflow-seldon" {
 # assign role to kubernetes pipeline runner
 resource "kubernetes_role_binding_v1" "k8s-seldon" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   metadata {
     name = "k8s-seldon"

--- a/aws-modular/seldon.tf
+++ b/aws-modular/seldon.tf
@@ -59,7 +59,7 @@ resource "kubernetes_role_binding_v1" "kubeflow-seldon" {
   count = (var.enable_kubeflow && var.enable_seldon) ? 1 : 0
 
   metadata {
-    name = "kubeflow-seldon"
+    name      = "kubeflow-seldon"
     namespace = kubernetes_namespace.seldon-workloads[0].metadata[0].name
   }
   role_ref {
@@ -84,7 +84,7 @@ resource "kubernetes_role_binding_v1" "k8s-seldon" {
   count = var.enable_seldon ? 1 : 0
 
   metadata {
-    name = "k8s-seldon"
+    name      = "k8s-seldon"
     namespace = kubernetes_namespace.seldon-workloads[0].metadata[0].name
   }
   role_ref {

--- a/aws-modular/tekton.tf
+++ b/aws-modular/tekton.tf
@@ -2,7 +2,7 @@
 module "tekton-pipelines" {
   source = "../modules/tekton-pipelines-module"
 
-  count = local.tekton.enable ? 1 : 0
+  count = var.enable_tekton ? 1 : 0
 
   # run only after the gke cluster is set up and cert-manager and nginx-ingress
   # are installed 
@@ -21,7 +21,7 @@ module "tekton-pipelines" {
 # the namespace where zenml will run tekton pipelines
 resource "kubernetes_namespace" "tekton-workloads" {
 
-  count = local.tekton.enable ? 1 : 0
+  count = var.enable_tekton ? 1 : 0
 
   metadata {
     name = local.tekton.workloads_namespace

--- a/aws-modular/tekton.tf
+++ b/aws-modular/tekton.tf
@@ -13,9 +13,9 @@ module "tekton-pipelines" {
     module.nginx-ingress,
   ]
 
-  pipeline_version = local.tekton.version
+  pipeline_version  = local.tekton.version
   dashboard_version = local.tekton.dashboard_version
-  ingress_host = local.tekton.ingress_host
+  ingress_host      = local.tekton.ingress_host
 }
 
 # the namespace where zenml will run tekton pipelines

--- a/aws-modular/variables.tf
+++ b/aws-modular/variables.tf
@@ -1,3 +1,29 @@
+# enable services
+variable "enable_kubeflow" {
+  description = "Enable Kubeflow deployment"
+  default     = true
+}
+variable "enable_tekton" {
+  description = "Enable Tekton deployment"
+  default     = true
+}
+variable "enable_mlflow" {
+  description = "Enable MLflow deployment"
+  default     = true
+}
+variable "enable_kserve" {
+  description = "Enable KServe deployment"
+  default     = true
+}
+variable "enable_seldon" {
+  description = "Enable Seldon deployment"
+  default     = true
+}
+variable "enable_zenml" {
+  description = "Enable ZenML deployment"
+  default     = true
+}
+
 # variables for the MLflow tracking server
 variable "mlflow-artifact-S3-access-key" {
   description = "Your AWS access key for using S3 as MLflow artifact store"

--- a/aws-modular/zenml.tf
+++ b/aws-modular/zenml.tf
@@ -13,17 +13,17 @@ module "zenml" {
   ]
 
   # details about the zenml deployment
-  chart_version           = local.zenml.version
-  username                = var.zenml-username
-  password                = var.zenml-password
-  database_url            = var.zenml-database-url
-  database_ssl_ca         = local.zenml.database_ssl_ca
-  database_ssl_cert       = local.zenml.database_ssl_cert
-  database_ssl_key        = local.zenml.database_ssl_key
+  chart_version                   = local.zenml.version
+  username                        = var.zenml-username
+  password                        = var.zenml-password
+  database_url                    = var.zenml-database-url
+  database_ssl_ca                 = local.zenml.database_ssl_ca
+  database_ssl_cert               = local.zenml.database_ssl_cert
+  database_ssl_key                = local.zenml.database_ssl_key
   database_ssl_verify_server_cert = local.zenml.database_ssl_verify_server_cert
- 
-  ingress_host            = local.zenml.ingress_host
-  ingress_tls = true
+
+  ingress_host          = local.zenml.ingress_host
+  ingress_tls           = true
   zenmlserver_image_tag = local.zenml.image_tag
-  zenmlinit_image_tag = local.zenml.image_tag
+  zenmlinit_image_tag   = local.zenml.image_tag
 }

--- a/aws-modular/zenml.tf
+++ b/aws-modular/zenml.tf
@@ -2,7 +2,7 @@
 module "zenml" {
   source = "../modules/zenml-module"
 
-  count = local.zenml.enable ? 1 : 0
+  count = var.enable_zenml ? 1 : 0
 
   # run only after the eks cluster, cert-manager and nginx-ingress are set up
   depends_on = [

--- a/gcp-modular/istio.tf
+++ b/gcp-modular/istio.tf
@@ -2,7 +2,7 @@
 module "istio" {
   source = "../modules/istio-module"
 
-  count = (local.kserve.enable || local.seldon.enable) ? 1 : 0
+  count = (var.enable_kserve || var.enable_seldon) ? 1 : 0
 
   depends_on = [
     module.gke,

--- a/gcp-modular/kserve.tf
+++ b/gcp-modular/kserve.tf
@@ -2,7 +2,7 @@
 module "kserve" {
   source = "../modules/kserve-module"
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   depends_on = [
     module.gke,
@@ -19,7 +19,7 @@ module "kserve" {
 # the namespace where zenml will deploy kserve models
 resource "kubernetes_namespace" "kserve-workloads" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   metadata {
     name = local.kserve.workloads_namespace
@@ -37,7 +37,7 @@ resource "kubernetes_namespace" "kserve-workloads" {
 # it will deploy models
 resource "kubernetes_cluster_role_v1" "kserve" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   metadata {
     name = "kserve-workloads"
@@ -60,7 +60,7 @@ resource "kubernetes_cluster_role_v1" "kserve" {
 # assign role to kubeflow pipeline runner
 resource "kubernetes_role_binding_v1" "kubeflow-kserve" {
 
-  count =  (local.kserve.enable && local.kubeflow.enable) ? 1 : 0
+  count =  (var.enable_kserve && var.enable_kubeflow) ? 1 : 0
 
   metadata {
     name = "kubeflow-kserve"
@@ -87,7 +87,7 @@ resource "kubernetes_role_binding_v1" "kubeflow-kserve" {
 # assign role to kubernetes pipeline runner
 resource "kubernetes_role_binding_v1" "k8s-kserve" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   metadata {
     name = "k8s-kserve"
@@ -113,7 +113,7 @@ resource "kubernetes_role_binding_v1" "k8s-kserve" {
 # service account for Kserve
 resource "google_service_account" "kserve-service-account" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   account_id   = "${local.prefix}-${local.kserve.service_account_name}"
   project      = local.project_id
@@ -121,7 +121,7 @@ resource "google_service_account" "kserve-service-account" {
 }
 resource "google_project_iam_binding" "kserve-storageviewer" {
 
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   project = local.project_id
   role    = "roles/storage.objectViewer"
@@ -141,7 +141,7 @@ resource "google_project_iam_binding" "kserve-storageviewer" {
 
 # creating a sa key
 resource "google_service_account_key" "kserve_sa_key" {
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   service_account_id = google_service_account.kserve-service-account[0].name
   public_key_type    = "TYPE_X509_PEM_FILE"
@@ -149,7 +149,7 @@ resource "google_service_account_key" "kserve_sa_key" {
 
 # create the credentials file JSON
 resource "local_file" "kserve_sa_key_file" {
-  count = local.kserve.enable ? 1 : 0
+  count = var.enable_kserve ? 1 : 0
 
   content  = base64decode(google_service_account_key.kserve_sa_key[0].private_key)
   filename = "./kserve_sa_key.json"

--- a/gcp-modular/kserve.tf
+++ b/gcp-modular/kserve.tf
@@ -12,8 +12,8 @@ module "kserve" {
   ]
 
   knative_version = local.kserve.knative_version
-  kserve_version = local.kserve.version
-  kserve_domain = "${local.kserve.ingress_host_prefix}.${module.istio[0].ingress-ip-address}.nip.io"
+  kserve_version  = local.kserve.version
+  kserve_domain   = "${local.kserve.ingress_host_prefix}.${module.istio[0].ingress-ip-address}.nip.io"
 }
 
 # the namespace where zenml will deploy kserve models
@@ -60,10 +60,10 @@ resource "kubernetes_cluster_role_v1" "kserve" {
 # assign role to kubeflow pipeline runner
 resource "kubernetes_role_binding_v1" "kubeflow-kserve" {
 
-  count =  (var.enable_kserve && var.enable_kubeflow) ? 1 : 0
+  count = (var.enable_kserve && var.enable_kubeflow) ? 1 : 0
 
   metadata {
-    name = "kubeflow-kserve"
+    name      = "kubeflow-kserve"
     namespace = kubernetes_namespace.kserve-workloads[0].metadata[0].name
   }
   role_ref {
@@ -90,7 +90,7 @@ resource "kubernetes_role_binding_v1" "k8s-kserve" {
   count = var.enable_kserve ? 1 : 0
 
   metadata {
-    name = "k8s-kserve"
+    name      = "k8s-kserve"
     namespace = kubernetes_namespace.kserve-workloads[0].metadata[0].name
   }
   role_ref {

--- a/gcp-modular/kubeflow.tf
+++ b/gcp-modular/kubeflow.tf
@@ -14,7 +14,7 @@ module "kubeflow-pipelines" {
   ]
 
   pipeline_version = local.kubeflow.version
-  ingress_host = "${local.kubeflow.ingress_host_prefix}.${module.nginx-ingress[0].ingress-ip-address}.nip.io"
+  ingress_host     = "${local.kubeflow.ingress_host_prefix}.${module.nginx-ingress[0].ingress-ip-address}.nip.io"
 }
 
 # tie the kubeflow kubernetes SA to the GKE service account

--- a/gcp-modular/kubeflow.tf
+++ b/gcp-modular/kubeflow.tf
@@ -2,7 +2,7 @@
 module "kubeflow-pipelines" {
   source = "../modules/kubeflow-pipelines-module"
 
-  count = local.kubeflow.enable ? 1 : 0
+  count = var.enable_kubeflow ? 1 : 0
 
   # run only after the gke cluster is set up and cert-manager and nginx-ingress
   # are installed 
@@ -20,7 +20,7 @@ module "kubeflow-pipelines" {
 # tie the kubeflow kubernetes SA to the GKE service account
 resource "null_resource" "kubeflow-sa-workload-access" {
 
-  count = local.kubeflow.enable ? 1 : 0
+  count = var.enable_kubeflow ? 1 : 0
 
   provisioner "local-exec" {
     command = "kubectl -n kubeflow annotate serviceaccount pipeline-runner iam.gke.io/gcp-service-account=${google_service_account.gke-service-account.email} --overwrite=true"
@@ -36,7 +36,7 @@ resource "null_resource" "kubeflow-sa-workload-access" {
 # Vertex AI resources, which are needed for ZenML pipelines
 resource "google_service_account_iam_member" "kubeflow-workload-access" {
 
-  count = local.kubeflow.enable ? 1 : 0
+  count = var.enable_kubeflow ? 1 : 0
 
   service_account_id = google_service_account.gke-service-account.name
   role               = "roles/iam.workloadIdentityUser"

--- a/gcp-modular/locals.tf
+++ b/gcp-modular/locals.tf
@@ -42,13 +42,11 @@ locals {
   }
 
   kubeflow = {
-    enable              = true
     version             = "1.8.3"
     ingress_host_prefix = "kubeflow"
   }
 
   tekton = {
-    enable              = true
     version             = "0.42.0"
     dashboard_version   = "0.31.0"
     ingress_host_prefix = "tekton"
@@ -56,7 +54,6 @@ locals {
   }
 
   mlflow = {
-    enable                  = true
     version                 = "0.7.13"
     artifact_Proxied_Access = "false"
     artifact_GCS            = "true"
@@ -66,7 +63,6 @@ locals {
   }
 
   kserve = {
-    enable               = true
     version              = "0.9.0" 
     knative_version      = "1.8.1"
     workloads_namespace  = "zenml-workloads-kserve"
@@ -75,7 +71,6 @@ locals {
   }
 
   seldon = {
-    enable               = true
     version              = "1.15.0"
     name                 = "seldon"
     namespace            = "seldon-system"
@@ -84,7 +79,6 @@ locals {
   }
 
   zenml = {
-    enable                  = true
     version                 = ""
     database_ssl_ca         = ""
     database_ssl_cert       = ""

--- a/gcp-modular/locals.tf
+++ b/gcp-modular/locals.tf
@@ -50,7 +50,7 @@ locals {
     version             = "0.42.0"
     dashboard_version   = "0.31.0"
     ingress_host_prefix = "tekton"
-    workloads_namespace  = "zenml-workloads-tekton"
+    workloads_namespace = "zenml-workloads-tekton"
   }
 
   mlflow = {
@@ -58,12 +58,12 @@ locals {
     artifact_Proxied_Access = "false"
     artifact_GCS            = "true"
     # if not set, the bucket created as part of the deployment will be used
-    artifact_GCS_Bucket     = ""
-    ingress_host_prefix     = "mlflow"
+    artifact_GCS_Bucket = ""
+    ingress_host_prefix = "mlflow"
   }
 
   kserve = {
-    version              = "0.9.0" 
+    version              = "0.9.0"
     knative_version      = "1.8.1"
     workloads_namespace  = "zenml-workloads-kserve"
     service_account_name = "kserve"
@@ -79,14 +79,14 @@ locals {
   }
 
   zenml = {
-    version                 = ""
-    database_ssl_ca         = ""
-    database_ssl_cert       = ""
-    database_ssl_key        = ""
-    database_ssl_verify_server_cert = false  
-    ingress_host_prefix     = "zenml"
-    ingress_tls             = true
-    image_tag               = ""
+    version                         = ""
+    database_ssl_ca                 = ""
+    database_ssl_cert               = ""
+    database_ssl_key                = ""
+    database_ssl_verify_server_cert = false
+    ingress_host_prefix             = "zenml"
+    ingress_tls                     = true
+    image_tag                       = ""
   }
 
   tags = {

--- a/gcp-modular/mlflow.tf
+++ b/gcp-modular/mlflow.tf
@@ -2,7 +2,7 @@
 module "mlflow" {
   source = "../modules/mlflow-module"
 
-  count = local.mlflow.enable ? 1 : 0
+  count = var.enable_mlflow ? 1 : 0
 
   # run only after the gke cluster, cert-manager and nginx-ingress are set up
   depends_on = [
@@ -28,7 +28,7 @@ resource "htpasswd_password" "hash" {
 # tie the mlflow kubernetes SA to the GKE service account
 resource "null_resource" "mlflow-sa-workload-access" {
 
-  count = local.mlflow.enable ? 1 : 0
+  count = var.enable_mlflow ? 1 : 0
 
   provisioner "local-exec" {
     command = "kubectl -n mlflow annotate serviceaccount mlflow-tracking iam.gke.io/gcp-service-account=${google_service_account.gke-service-account.email} --overwrite=true"
@@ -43,7 +43,7 @@ resource "null_resource" "mlflow-sa-workload-access" {
 # # the GKE IAM role should have access to Storage resources
 resource "google_service_account_iam_member" "mlflow-storage-access" {
 
-  count = local.mlflow.enable ? 1 : 0
+  count = var.enable_mlflow ? 1 : 0
 
   service_account_id = google_service_account.gke-service-account.name
   role               = "roles/iam.workloadIdentityUser"

--- a/gcp-modular/nginx_ingress.tf
+++ b/gcp-modular/nginx_ingress.tf
@@ -2,7 +2,7 @@
 module "nginx-ingress" {
   source = "../modules/nginx-ingress-module"
 
-  count = (local.mlflow.enable || local.kubeflow.enable || local.zenml.enable || local.tekton.enable) ? 1 : 0
+  count = (var.enable_mlflow || var.enable_kubeflow || var.enable_zenml || var.enable_tekton) ? 1 : 0
 
   # run only after the gke cluster is set up
   depends_on = [

--- a/gcp-modular/output_file.tf
+++ b/gcp-modular/output_file.tf
@@ -31,12 +31,12 @@ resource "local_file" "stack_file" {
         id: ${uuid()}
         flavor: mlflow
         name: gke_mlflow_experiment_tracker
-        configuration: {"tracking_uri": "${local.mlflow.enable ? module.mlflow[0].mlflow-tracking-URL : ""}", "tracking_username": "${var.mlflow-username}", "tracking_password": "${var.mlflow-password}"}
+        configuration: {"tracking_uri": "${var.enable_mlflow ? module.mlflow[0].mlflow-tracking-URL : ""}", "tracking_username": "${var.mlflow-username}", "tracking_password": "${var.mlflow-password}"}
       model_deployer:
         id: ${uuid()}
         flavor: kserve
         name: gke_kserve
-        configuration: {"kubernetes_context": "gke_${local.project_id}_${local.region}_${module.gke.name}", "kubernetes_namespace": "${local.kserve.workloads_namespace}", "base_url": "${local.kserve.enable ? module.kserve[0].kserve-base-URL : ""}", "secret": "gcp_kserve_secret"}
+        configuration: {"kubernetes_context": "gke_${local.project_id}_${local.region}_${module.gke.name}", "kubernetes_namespace": "${local.kserve.workloads_namespace}", "base_url": "${var.enable_kserve ? module.kserve[0].kserve-base-URL : ""}", "secret": "gcp_kserve_secret"}
     ADD
   filename = "./gcp_kubeflow_stack_${replace(substr(timestamp(), 0, 16), ":", "_")}.yaml"
 }

--- a/gcp-modular/outputs.tf
+++ b/gcp-modular/outputs.tf
@@ -32,35 +32,35 @@ output "istio-ingress-hostname" {
 
 
 output "kubeflow-pipelines-ui-URL" {
-  value = local.kubeflow.enable ? module.kubeflow-pipelines[0].pipelines-ui-URL : null
+  value = var.enable_kubeflow ? module.kubeflow-pipelines[0].pipelines-ui-URL : null
 }
 
 output "tekton-pipelines-ui-URL" {
-  value = local.tekton.enable ? module.tekton-pipelines[0].pipelines-ui-URL : null
+  value = var.enable_tekton ? module.tekton-pipelines[0].pipelines-ui-URL : null
 }
 
 # outputs for the MLflow tracking server
 output "mlflow-tracking-URL" {
-  value = local.mlflow.enable ? module.mlflow[0].mlflow-tracking-URL : null
+  value = var.enable_mlflow ? module.mlflow[0].mlflow-tracking-URL : null
 }
 
 # output for kserve model deployer
 output "kserve-workload-namespace" {
-  value       = local.kserve.enable ? local.kserve.workloads_namespace : null
+  value       = var.enable_kserve ? local.kserve.workloads_namespace : null
   description = "The namespace created for hosting your Kserve workloads"
 }
 output "kserve-base-url" {
-  value = local.kserve.enable ? module.kserve[0].kserve-base-URL : null
+  value = var.enable_kserve ? module.kserve[0].kserve-base-URL : null
 }
 
 # output for seldon model deployer
 output "seldon-workload-namespace" {
-  value       = local.seldon.enable ? local.seldon.workloads_namespace : null
+  value       = var.enable_seldon ? local.seldon.workloads_namespace : null
   description = "The namespace created for hosting your Seldon workloads"
 }
 
 output "seldon-base-url" {
-  value = local.seldon.enable ? module.istio[0].ingress-ip-address : null
+  value = var.enable_seldon ? module.istio[0].ingress-ip-address : null
 }
 
 # output the name of the stack YAML file created
@@ -70,8 +70,8 @@ output "stack-yaml-path" {
 
 # outputs for the ZenML server
 output "zenml-url" {
-  value = local.zenml.enable ? module.zenml[0].zenml_server_url : null
+  value = var.enable_zenml ? module.zenml[0].zenml_server_url : null
 }
 output "zenml-username" {
-  value = local.zenml.enable ? module.zenml[0].username : null
+  value = var.enable_zenml ? module.zenml[0].username : null
 }

--- a/gcp-modular/seldon.tf
+++ b/gcp-modular/seldon.tf
@@ -59,7 +59,7 @@ resource "kubernetes_role_binding_v1" "kubeflow-seldon" {
   count = (var.enable_kubeflow && var.enable_seldon) ? 1 : 0
 
   metadata {
-    name = "kubeflow-seldon"
+    name      = "kubeflow-seldon"
     namespace = kubernetes_namespace.seldon-workloads[0].metadata[0].name
   }
   role_ref {
@@ -84,7 +84,7 @@ resource "kubernetes_role_binding_v1" "k8s-seldon" {
   count = var.enable_seldon ? 1 : 0
 
   metadata {
-    name = "k8s-seldon"
+    name      = "k8s-seldon"
     namespace = kubernetes_namespace.seldon-workloads[0].metadata[0].name
   }
   role_ref {

--- a/gcp-modular/seldon.tf
+++ b/gcp-modular/seldon.tf
@@ -3,7 +3,7 @@
 module "seldon" {
   source = "../modules/seldon-module"
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   # run only after the gke cluster and istio are set up
   depends_on = [
@@ -19,7 +19,7 @@ module "seldon" {
 # the namespace where zenml will deploy seldon models
 resource "kubernetes_namespace" "seldon-workloads" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   metadata {
     name = local.seldon.workloads_namespace
@@ -33,7 +33,7 @@ resource "kubernetes_namespace" "seldon-workloads" {
 # will deploy models
 resource "kubernetes_cluster_role_v1" "seldon" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   metadata {
     name = "seldon-workloads"
@@ -56,7 +56,7 @@ resource "kubernetes_cluster_role_v1" "seldon" {
 # assign role to kubeflow pipeline runner
 resource "kubernetes_role_binding_v1" "kubeflow-seldon" {
 
-  count = (local.kubeflow.enable && local.seldon.enable) ? 1 : 0
+  count = (var.enable_kubeflow && var.enable_seldon) ? 1 : 0
 
   metadata {
     name = "kubeflow-seldon"
@@ -81,7 +81,7 @@ resource "kubernetes_role_binding_v1" "kubeflow-seldon" {
 # assign role to kubernetes pipeline runner
 resource "kubernetes_role_binding_v1" "k8s-seldon" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   metadata {
     name = "k8s-seldon"
@@ -103,7 +103,7 @@ resource "kubernetes_role_binding_v1" "k8s-seldon" {
 # service account for Seldon
 resource "google_service_account" "seldon-service-account" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   account_id   = "${local.prefix}-${local.seldon.service_account_name}"
   project      = local.project_id
@@ -111,7 +111,7 @@ resource "google_service_account" "seldon-service-account" {
 }
 resource "google_project_iam_binding" "seldon-storageviewer" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   project = local.project_id
   role    = "roles/storage.objectViewer"
@@ -132,7 +132,7 @@ resource "google_project_iam_binding" "seldon-storageviewer" {
 # creating a sa key
 resource "google_service_account_key" "seldon_sa_key" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   service_account_id = google_service_account.seldon-service-account[0].name
   public_key_type    = "TYPE_X509_PEM_FILE"
@@ -141,7 +141,7 @@ resource "google_service_account_key" "seldon_sa_key" {
 # create the credentials file JSON
 resource "local_file" "seldon_sa_key_file" {
 
-  count = local.seldon.enable ? 1 : 0
+  count = var.enable_seldon ? 1 : 0
 
   content  = base64decode(google_service_account_key.seldon_sa_key[0].private_key)
   filename = "./seldon_sa_key.json"

--- a/gcp-modular/tekton.tf
+++ b/gcp-modular/tekton.tf
@@ -2,7 +2,7 @@
 module "tekton-pipelines" {
   source = "../modules/tekton-pipelines-module"
 
-  count = local.tekton.enable ? 1 : 0
+  count = var.enable_tekton ? 1 : 0
 
   # run only after the gke cluster is set up and cert-manager and nginx-ingress
   # are installed 
@@ -21,7 +21,7 @@ module "tekton-pipelines" {
 # the namespace where zenml will run tekton pipelines
 resource "kubernetes_namespace" "tekton-workloads" {
 
-  count = local.tekton.enable ? 1 : 0
+  count = var.enable_tekton ? 1 : 0
 
   metadata {
     name = local.tekton.workloads_namespace
@@ -35,7 +35,7 @@ resource "kubernetes_namespace" "tekton-workloads" {
 # tie the tekton kubernetes SA to the GKE service account
 resource "null_resource" "tekton-sa-workload-access" {
 
-  count = local.tekton.enable ? 1 : 0
+  count = var.enable_tekton ? 1 : 0
 
   provisioner "local-exec" {
     command = "kubectl -n ${kubernetes_namespace.tekton-workloads[0].metadata[0].name} annotate serviceaccount default iam.gke.io/gcp-service-account=${google_service_account.gke-service-account.email} --overwrite=true"
@@ -51,7 +51,7 @@ resource "null_resource" "tekton-sa-workload-access" {
 # Vertex AI resources, which are needed for ZenML pipelines
 resource "google_service_account_iam_member" "tekton-workload-access" {
 
-  count = local.tekton.enable ? 1 : 0
+  count = var.enable_tekton ? 1 : 0
 
   service_account_id = google_service_account.gke-service-account.name
   role               = "roles/iam.workloadIdentityUser"

--- a/gcp-modular/tekton.tf
+++ b/gcp-modular/tekton.tf
@@ -13,9 +13,9 @@ module "tekton-pipelines" {
     module.nginx-ingress,
   ]
 
-  pipeline_version = local.tekton.version
+  pipeline_version  = local.tekton.version
   dashboard_version = local.tekton.dashboard_version
-  ingress_host = "${local.tekton.ingress_host_prefix}.${module.nginx-ingress[0].ingress-ip-address}.nip.io"
+  ingress_host      = "${local.tekton.ingress_host_prefix}.${module.nginx-ingress[0].ingress-ip-address}.nip.io"
 }
 
 # the namespace where zenml will run tekton pipelines

--- a/gcp-modular/variables.tf
+++ b/gcp-modular/variables.tf
@@ -1,3 +1,29 @@
+# enable services
+variable "enable_kubeflow" {
+  description = "Enable Kubeflow deployment"
+  default     = true
+}
+variable "enable_tekton" {
+  description = "Enable Tekton deployment"
+  default     = true
+}
+variable "enable_mlflow" {
+  description = "Enable MLflow deployment"
+  default     = true
+}
+variable "enable_kserve" {
+  description = "Enable KServe deployment"
+  default     = true
+}
+variable "enable_seldon" {
+  description = "Enable Seldon deployment"
+  default     = true
+}
+variable "enable_zenml" {
+  description = "Enable ZenML deployment"
+  default     = true
+}
+
 # variables for the MLflow tracking server
 variable "mlflow-username" {
   description = "The username for the MLflow Tracking Server"

--- a/gcp-modular/zenml.tf
+++ b/gcp-modular/zenml.tf
@@ -2,7 +2,7 @@
 module "zenml" {
   source = "../modules/zenml-module"
 
-  count = local.zenml.enable ? 1 : 0
+  count = var.enable_zenml ? 1 : 0
 
   # run only after the gke cluster, cert-manager and nginx-ingress are set up
   depends_on = [

--- a/gcp-modular/zenml.tf
+++ b/gcp-modular/zenml.tf
@@ -13,17 +13,17 @@ module "zenml" {
   ]
 
   # details about the zenml deployment
-  chart_version           = local.zenml.version
-  username                = var.zenml-username
-  password                = var.zenml-password
-  database_url            = var.zenml-database-url
-  database_ssl_ca         = local.zenml.database_ssl_ca
-  database_ssl_cert       = local.zenml.database_ssl_cert
-  database_ssl_key        = local.zenml.database_ssl_key
+  chart_version                   = local.zenml.version
+  username                        = var.zenml-username
+  password                        = var.zenml-password
+  database_url                    = var.zenml-database-url
+  database_ssl_ca                 = local.zenml.database_ssl_ca
+  database_ssl_cert               = local.zenml.database_ssl_cert
+  database_ssl_key                = local.zenml.database_ssl_key
   database_ssl_verify_server_cert = local.zenml.database_ssl_verify_server_cert
- 
-  ingress_host            = "${local.zenml.ingress_host_prefix}.${module.nginx-ingress[0].ingress-ip-address}.nip.io"
-  ingress_tls = true
+
+  ingress_host          = "${local.zenml.ingress_host_prefix}.${module.nginx-ingress[0].ingress-ip-address}.nip.io"
+  ingress_tls           = true
   zenmlserver_image_tag = local.zenml.image_tag
-  zenmlinit_image_tag = local.zenml.image_tag
+  zenmlinit_image_tag   = local.zenml.image_tag
 }


### PR DESCRIPTION
## Description
I changed all local enable params to be terraform variables. This allows them to be passed as JSON file, which in turns makes it easier for a python script to control them.

## Application
These variables will be used by the `zenml stack recipe deploy` CLI to control what components to deploy. A new feature of this CLI command is enabling flags to be set to activate individual components.