### PR TITLE
Update kserve and add some fixes

### DIFF
--- a/aws-kubeflow-kserve/kserve-module/istio.tf
+++ b/aws-kubeflow-kserve/kserve-module/istio.tf
@@ -1,32 +1,32 @@
 # set up istio for kserve
 resource "null_resource" "create-istio-kserve" {
   provisioner "local-exec" {
-    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   # repeating the same command as a hack to prevent errors in subsequent commands
   # running it only once would have caused the next command to fail with no envoyfilter CRDs.
   provisioner "local-exec" {
-    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/net-istio.yaml"
+    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/net-istio.yaml"
   }
 
   # destroy-time provisioners
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl delete -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/net-istio.yaml"
+    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/net-istio.yaml --ignore-not-found"
   }
 
   depends_on = [

--- a/aws-kubeflow-kserve/kserve-module/knative_serving.tf
+++ b/aws-kubeflow-kserve/kserve-module/knative_serving.tf
@@ -1,20 +1,20 @@
 # set up istio for kserve
 resource "null_resource" "create-knative-serving" {
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-crds.yaml"
+    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-crds.yaml"
   }
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-core.yaml"
+    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-core.yaml"
   }
 
   # destroy-time provisioners
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-crds.yaml"
+    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-crds.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-core.yaml"
+    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-core.yaml --ignore-not-found"
   }
 
 }

--- a/gcp-kubeflow-kserve/kserve-module/istio.tf
+++ b/gcp-kubeflow-kserve/kserve-module/istio.tf
@@ -1,32 +1,32 @@
 # set up istio for kserve
 resource "null_resource" "create-istio-kserve" {
   provisioner "local-exec" {
-    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   # repeating the same command as a hack to prevent errors in subsequent commands
   # running it only once would have caused the next command to fail with no envoyfilter CRDs.
   provisioner "local-exec" {
-    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl apply -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/net-istio.yaml"
+    command = "kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/net-istio.yaml"
   }
 
   # destroy-time provisioners
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl delete -l knative.dev/crd-install=true -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/istio.yaml"
+    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/istio.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.6.0/net-istio.yaml"
+    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v1.9.0/net-istio.yaml --ignore-not-found"
   }
 
   depends_on = [

--- a/gcp-kubeflow-kserve/kserve-module/knative_serving.tf
+++ b/gcp-kubeflow-kserve/kserve-module/knative_serving.tf
@@ -1,20 +1,20 @@
 # set up istio for kserve
 resource "null_resource" "create-knative-serving" {
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-crds.yaml"
+    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-crds.yaml"
   }
   provisioner "local-exec" {
-    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-core.yaml"
+    command = "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-core.yaml"
   }
 
   # destroy-time provisioners
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-crds.yaml"
+    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-crds.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-core.yaml"
+    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-core.yaml --ignore-not-found"
   }
 
 }

--- a/gcp-kubeflow-kserve/kserve-module/kserve.tf
+++ b/gcp-kubeflow-kserve/kserve-module/kserve.tf
@@ -10,11 +10,11 @@ resource "null_resource" "kserve" {
   # destroy-time provisioners
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v0.9.0/kserve.yaml"
+    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v0.9.0/kserve.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v0.9.0/kserve-runtimes.yaml"
+    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v0.9.0/kserve-runtimes.yaml --ignore-not-found"
   }
 
   depends_on = [

--- a/modules/kserve-module/knative_serving.tf
+++ b/modules/kserve-module/knative_serving.tf
@@ -17,15 +17,15 @@ resource "null_resource" "knative-serving" {
   # destroy-time provisioners
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v${self.triggers.knative_version}/net-istio.yaml"
+    command = "kubectl delete -f https://github.com/knative/net-istio/releases/download/knative-v${self.triggers.knative_version}/net-istio.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v${self.triggers.knative_version}/serving-core.yaml"
+    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v${self.triggers.knative_version}/serving-core.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v${self.triggers.knative_version}/serving-crds.yaml"
+    command = "kubectl delete -f https://github.com/knative/serving/releases/download/knative-v${self.triggers.knative_version}/serving-crds.yaml --ignore-not-found"
   }
 
 }

--- a/modules/kserve-module/kserve.tf
+++ b/modules/kserve-module/kserve.tf
@@ -13,11 +13,11 @@ resource "null_resource" "kserve" {
   # destroy-time provisioners
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v${self.triggers.kserve_version}/kserve-runtimes.yaml"
+    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v${self.triggers.kserve_version}/kserve-runtimes.yaml --ignore-not-found"
   }
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v${self.triggers.kserve_version}/kserve.yaml"
+    command = "kubectl delete -f https://github.com/kserve/kserve/releases/download/v${self.triggers.kserve_version}/kserve.yaml --ignore-not-found"
   }
 
   depends_on = [


### PR DESCRIPTION
- Version upgraded from 1.6 to 1.9 for kserve terraform module (knative & istio).
- graceful failure of the `kubectl delete` command when no resources exist.
- Add workload identity annotation to kubeflow's pipelin-runner service account.
