### PR TITLE
Update name of Vertex recipe to `gcp-vertexai` from `vertex-ai`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Watch it below:
 | [gcp-airflow](https://github.com/zenml-io/mlops-stacks/tree/main/gcp-airflow) | Managed Airflow using GCP Cloud Composer, GCS Bucket, GCR | A recipe that creates a Cloud Composer environment that enables a managed Airflow environment as orchestrator, a GCS artifact store and a GCR container registry |
 | [gcp-kubeflow-kserve](https://github.com/zenml-io/mlops-stacks/tree/main/gcp-kubeflow-kserve) | Kubeflow on GKE, GCS Bucket, GCR, MLflow Tracking, KServe, Vertex | A recipe that creates a Kubeflow pipelines cluster as orchestrator, GCS artifact store, GCR container registry,  MLflow experiment tracker, KServe model deployer and option for Vertex AI as a step operator |
 | [gcp-minimal](https://github.com/zenml-io/mlops-stacks/tree/main/gcp-minimal) | GKE, GCS Bucket, GCR, MLflow Tracking, Seldon | GCP specific recipe to showcase a production-grade MLOps Stack with a GKE orchestrator, GCS artifact store, GCR container repository, MLflow experiment tracker and Seldon Core model deployer |
-| [vertex-ai](https://github.com/zenml-io/mlops-stacks/tree/main/vertex-ai) | Vertex AI Pipelines, GCS Bucket, GCR and (optional) MLflow Tracking | A stack with a Vertex AI orchestrator, GCS artifact store, GCR container registry and an optional MLflow experiment tracker |
+| [gcp-vertexai](https://github.com/zenml-io/mlops-stacks/tree/main/gcp-vertexai) | Vertex AI Pipelines, GCS Bucket, GCR and (optional) MLflow Tracking | A stack with a Vertex AI orchestrator, GCS artifact store, GCR container registry and an optional MLflow experiment tracker |
 
 ## 🙏 Association with ZenML
 

--- a/gcp-vertexai/README.md
+++ b/gcp-vertexai/README.md
@@ -44,7 +44,7 @@ However, ZenML works seamlessly with the infrastructure provisioned through thes
 1. Pull this recipe to your local system.
 
     ```shell
-    zenml stack recipe pull vertex-ai
+    zenml stack recipe pull gcp-vertexai
     ```
 2. 🎨 Customize your deployment by editing the default values in the `locals.tf` file.
 
@@ -53,7 +53,7 @@ However, ZenML works seamlessly with the infrastructure provisioned through thes
 5. 🚀 Deploy the recipe with this simple command.
 
     ```
-    zenml stack recipe deploy vertex-ai
+    zenml stack recipe deploy gcp-vertexai
     ```
 
     On the Vertex dashboard, under "Training" tab on the left, and under the "Custom Jobs" section, you will see that a dummy run gets created. This is done to trigger creation of a Vertex service agent and you can cancel and/or delete this job. 


### PR DESCRIPTION
Two of the README stills referenced the Vertex recipe as `vertex-ai` which has apparently been changed to `gcp-vertexai`.