### PR TITLE
Add spellcheck to CI

### DIFF
--- a/.github/workflows/recipe-test.yml
+++ b/.github/workflows/recipe-test.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         files: "."
         config: ./.typos.toml
+
   aws_test:
     name: aws_test
     runs-on: ubuntu-latest

--- a/.github/workflows/recipe-test.yml
+++ b/.github/workflows/recipe-test.yml
@@ -15,6 +15,18 @@ permissions:
       contents: read
 
 jobs:
+  spell-check:
+    name: spell-check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v2
+
+    - name: Spelling checker
+      uses: crate-ci/typos@master
+      with:
+        files: "."
+        config: ./.typos.toml
   aws_test:
     name: aws_test
     runs-on: ubuntu-latest

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,22 @@
+[files]
+# extend-exclude = ["*.json", "*.js", "*.ipynb", "src/zenml/zen_stores/migrations/versions/", "tests/unit/materializers/test_built_in_materializer.py", "tests/integration/functional/cli/test_pipeline.py"]
+
+[default.extend-identifiers]
+HashiCorp = "HashiCorp"
+
+
+[default.extend-words]
+aks = "aks"
+hashi = "hashi"
+womens = "womens"
+prepend = "prepend"
+prepended = "prepended"
+goes = "goes"
+bare = "bare"
+prepending = "prepending"
+prev = "prev"
+creat = "creat"
+ret = "ret"
+
+[default]
+locale = "en-us"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Watch it below:
 
 [![maintained-by-zenml](https://user-images.githubusercontent.com/3348134/173032050-ad923313-f2ce-4583-b27a-afcaa8b355e2.png)](https://github.com/zenml-io/zenml)
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 

--- a/aws-kubeflow-kserve/README.md
+++ b/aws-kubeflow-kserve/README.md
@@ -1,6 +1,6 @@
 # 🍭 Kubeflow, S3, MLflow and Kserve MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -154,7 +154,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/aws-kubeflow-kserve/eks.tf
+++ b/aws-kubeflow-kserve/eks.tf
@@ -1,4 +1,4 @@
-# eks module to creater a cluster
+# eks module to create a cluster
 # newer versions of it had some error so going with v17.23.0 for now
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"

--- a/aws-kubeflow-kserve/mlflow-module/README.md
+++ b/aws-kubeflow-kserve/mlflow-module/README.md
@@ -19,7 +19,7 @@ ingress-controller-namespace | Used for getting the ingress URL for the MLflow t
 
 The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
 
-However, you can also manually query the URL by using the folowing command.
+However, you can also manually query the URL by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/aws-minimal/README.md
+++ b/aws-minimal/README.md
@@ -1,6 +1,6 @@
 # 🥗 EKS, S3, MLflow and Seldon MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -129,7 +129,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/aws-minimal/eks.tf
+++ b/aws-minimal/eks.tf
@@ -1,4 +1,4 @@
-# eks module to creater a cluster
+# eks module to create a cluster
 # newer versions of it had some error so going with v17.23.0 for now
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"

--- a/aws-minimal/mlflow-module/README.md
+++ b/aws-minimal/mlflow-module/README.md
@@ -19,7 +19,7 @@ ingress-controller-namespace | Used for getting the ingress URL for the MLflow t
 
 The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
 
-However, you can also manually query the URL by using the folowing command.
+However, you can also manually query the URL by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/aws-minimal/seldon/seldon.tf
+++ b/aws-minimal/seldon/seldon.tf
@@ -14,7 +14,7 @@ resource "helm_release" "seldon" {
   # dependency on seldon-ns
   namespace = kubernetes_namespace.seldon-ns.metadata[0].name
 
-  # values dervied from the zenml seldon-core example at
+  # values derived from the zenml seldon-core example at
   # https://github.com/zenml-io/zenml/blob/main/examples/seldon_deployment/README.md#installing-seldon-core-eg-in-an-eks-cluster
   set {
     name  = "usageMetrics.enabled"

--- a/aws-modular/README.md
+++ b/aws-modular/README.md
@@ -1,6 +1,6 @@
 # 🍭 Kubeflow, S3, MLflow and Kserve MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -154,7 +154,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/aws-modular/eks.tf
+++ b/aws-modular/eks.tf
@@ -1,4 +1,4 @@
-# eks module to creater a cluster
+# eks module to create a cluster
 # newer versions of it had some error so going with v17.23.0 for now
 locals {
   enable_eks = (var.enable_kubeflow || var.enable_tekton || var.enable_kubernetes ||

--- a/aws-stores-minimal/README.md
+++ b/aws-stores-minimal/README.md
@@ -1,6 +1,6 @@
 # 🥗 S3 and Secrets Manager MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -116,7 +116,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/azure-minimal/README.md
+++ b/azure-minimal/README.md
@@ -1,6 +1,6 @@
 # 🥙 Azure Minimal MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -170,7 +170,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/azure-minimal/mlflow-module/README.md
+++ b/azure-minimal/mlflow-module/README.md
@@ -19,7 +19,7 @@ ingress-controller-namespace | Used for getting the ingress URL for the MLflow t
 
 The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
 
-However, you can also manually query the URL by using the folowing command.
+However, you can also manually query the URL by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/azure-minimal/seldon/seldon.tf
+++ b/azure-minimal/seldon/seldon.tf
@@ -14,7 +14,7 @@ resource "helm_release" "seldon" {
   # dependency on seldon-ns
   namespace = kubernetes_namespace.seldon-ns.metadata[0].name
 
-  # values dervied from the zenml seldon-core example at
+  # values derived from the zenml seldon-core example at
   # https://github.com/zenml-io/zenml/blob/main/examples/seldon_deployment/README.md#installing-seldon-core-eg-in-an-eks-cluster
   set {
     name  = "usageMetrics.enabled"

--- a/azure-minimal/variables.tf
+++ b/azure-minimal/variables.tf
@@ -12,7 +12,7 @@ variable "mlflow-password" {
 }
 
 # this variable only needs to be set if you're using a 
-# pre-exisiting storage account (outside the scope of this recipe).
+# pre-existing storage account (outside the scope of this recipe).
 variable "mlflow-artifact-Azure-Access-Key" {
   description = "The access key for your Azure Storage account that you wish to use with MLflow"
   default     = ""

--- a/azureml-minimal/README.md
+++ b/azureml-minimal/README.md
@@ -1,6 +1,6 @@
 # 🥙 AzureML Minimal MLOps Stack Recipe
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further.
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -193,7 +193,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
 
     ```bash
     terraform init
@@ -238,7 +238,7 @@ export AZURE_STORAGE_CONNECTION_STRING=$(terraform output storage-account-connec
 export CONTAINER_PATH=$(terraform output blobstorage-container-path)
 
 # azureml
-export WORKSPACE_NAME=$(terraform output azureml-workpsace-name)
+export WORKSPACE_NAME=$(terraform output azureml-workspace-name)
 export CLUSTER_NAME=$(terraform output azureml-compute-cluster-name)
 export KEY_VAULT_NAME=$(terraform output key-vault-name)
 

--- a/azureml-minimal/outputs.tf
+++ b/azureml-minimal/outputs.tf
@@ -14,7 +14,7 @@ output "resource-group-location" {
 }
 
 # output for the AzureML workspace
-output "azureml-workpsace-name" {
+output "azureml-workspace-name" {
   value = "${local.prefix}-${local.azureml.cluster_name}-mlw"
 }
 output "azureml-compute-cluster-name" {

--- a/gcp-airflow/README.md
+++ b/gcp-airflow/README.md
@@ -1,6 +1,6 @@
 # 🥙 GCP Cloud Composer Airflow Stack Recipe
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -27,7 +27,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -114,7 +114,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/gcp-kubeflow-kserve/README.md
+++ b/gcp-kubeflow-kserve/README.md
@@ -1,6 +1,6 @@
 # 🍭 Kubeflow, Vertex, GCS, MLflow and Kserve MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -137,7 +137,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/gcp-kubeflow-kserve/mlflow-module/README.md
+++ b/gcp-kubeflow-kserve/mlflow-module/README.md
@@ -19,7 +19,7 @@ ingress-controller-namespace | Used for getting the ingress URL for the MLflow t
 
 The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
 
-However, you can also manually query the URL by using the folowing command.
+However, you can also manually query the URL by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/gcp-minimal/README.md
+++ b/gcp-minimal/README.md
@@ -1,6 +1,6 @@
 # 🥙 GKE, GCS, MLflow and Seldon MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -133,7 +133,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/gcp-minimal/mlflow-module/README.md
+++ b/gcp-minimal/mlflow-module/README.md
@@ -19,7 +19,7 @@ ingress-controller-namespace | Used for getting the ingress URL for the MLflow t
 
 The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
 
-However, you can also manually query the URL by using the folowing command.
+However, you can also manually query the URL by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/gcp-minimal/seldon/seldon.tf
+++ b/gcp-minimal/seldon/seldon.tf
@@ -14,7 +14,7 @@ resource "helm_release" "seldon" {
   # dependency on seldon-ns
   namespace = kubernetes_namespace.seldon-ns.metadata[0].name
 
-  # values dervied from the zenml seldon-core example at
+  # values derived from the zenml seldon-core example at
   # https://github.com/zenml-io/zenml/blob/main/examples/seldon_deployment/README.md#installing-seldon-core-eg-in-an-eks-cluster
   set {
     name  = "usageMetrics.enabled"

--- a/gcp-modular/README.md
+++ b/gcp-modular/README.md
@@ -1,6 +1,6 @@
 # 🍭 Kubeflow, Vertex, GCS, MLflow and Kserve MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -33,7 +33,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -137,7 +137,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/gcp-vertexai/README.md
+++ b/gcp-vertexai/README.md
@@ -1,6 +1,6 @@
 # 🥙 Vertex AI MLOps Stack Recipe 
 
-There can be many motivations behind taking your ML application setup to a cloud environment, from neeeding specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
+There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
 We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/cloud-guide/overview) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
 
@@ -35,7 +35,7 @@ Before starting, you should know the values that you have to keep ready for use 
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not neccessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 
@@ -133,7 +133,7 @@ As mentioned above, you can still use the recipe without having using the `zenml
 
 2. 🔐 Add your secret information like keys and passwords into the `values.tfvars.json` file which is not committed and only exists locally.
 
-3. Initiliaze Terraform modules and download provider definitions.
+3. Initialize Terraform modules and download provider definitions.
     ```bash
     terraform init
     ```

--- a/gcp-vertexai/mlflow-module/README.md
+++ b/gcp-vertexai/mlflow-module/README.md
@@ -19,7 +19,7 @@ ingress-controller-namespace | Used for getting the ingress URL for the MLflow t
 
 The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
 
-However, you can also manually query the URL by using the folowing command.
+However, you can also manually query the URL by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/gcp-vertexai/vertex.tf
+++ b/gcp-vertexai/vertex.tf
@@ -24,7 +24,7 @@ resource "google_project_iam_member" "roles-custom-sa" {
 }
 
 
-# create custom code service agent by trigerring a dummy run
+# create custom code service agent by triggering a dummy run
 resource "null_resource" "vertex-dummy-run" {
   provisioner "local-exec" {
     command = "gcloud beta ai custom-jobs create --display-name dummy --region ${local.region} --worker-pool-spec=replica-count=1,machine-type=e2-standard-4,container-image-uri=gcr.io/google-appengine/python --project ${local.project_id}"

--- a/k3d-modular/README.md
+++ b/k3d-modular/README.md
@@ -41,7 +41,7 @@ The `k3d.local_stores_path` variable is used to customize the path on your syste
 
 ## 🧑‍🍳 Cooking the recipe
 
-It is not necessary to use the MLOps stacks recipes presented here alongisde the
+It is not necessary to use the MLOps stacks recipes presented here alongside the
 [ZenML](https://github.com/zenml-io/zenml) framework. You can simply use the Terraform scripts
 directly.
 

--- a/modules/mlflow-module/README.md
+++ b/modules/mlflow-module/README.md
@@ -19,7 +19,7 @@ ingress-controller-namespace | Used for getting the ingress URL for the MLflow t
 
 The tracking URI is obtained by querying the relevant Kubernetes service that exposes the tracking server. This is done automatically when you execute any recipe. You can use the `mlflow-tracking-URL` output to get this value.
 
-However, you can also manually query the URL by using the folowing command.
+However, you can also manually query the URL by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/modules/nginx-ingress-module/README.md
+++ b/modules/nginx-ingress-module/README.md
@@ -16,7 +16,7 @@ ingress-controller-name | Used for getting the name of the helm nginx-ingress re
 
 The ingress hostname or IP address is obtained by querying the relevant Kubernetes service that exposes the ingress service..
 
-However, you can also manually query the hotname by using the folowing command.
+However, you can also manually query the hostname by using the following command.
 
 ```
 kubectl get service <ingress-controller-name>-ingress-nginx-controller -n <ingress-controller-namespace>

--- a/modules/seldon-module/seldon.tf
+++ b/modules/seldon-module/seldon.tf
@@ -16,7 +16,7 @@ resource "helm_release" "seldon" {
   # dependency on seldon-ns
   namespace = kubernetes_namespace.seldon-ns.metadata[0].name
 
-  # values dervied from the zenml seldon-core example at
+  # values derived from the zenml seldon-core example at
   # https://github.com/zenml-io/zenml/blob/main/examples/seldon_deployment/README.md#installing-seldon-core-eg-in-an-eks-cluster
   set {
     name  = "usageMetrics.enabled"


### PR DESCRIPTION
Added `typos` into the CI to ensure small typos don't make it onto main. (Same as we have on the main `zenml` repo.)

(Also fixed whatever needed fixing in terms of what was already there.)