### PR TITLE
update vpc version for AWS stacks

### DIFF
--- a/aws-kubeflow-kserve/vpc.tf
+++ b/aws-kubeflow-kserve/vpc.tf
@@ -1,7 +1,7 @@
 # VPC infra using https://github.com/terraform-aws-modules/terraform-aws-vpc
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = ">= 4.0.0"
 
   name = "${local.prefix}-${local.vpc.name}"
   cidr = "10.10.0.0/16"

--- a/aws-minimal/vpc.tf
+++ b/aws-minimal/vpc.tf
@@ -1,7 +1,7 @@
 # VPC infra using https://github.com/terraform-aws-modules/terraform-aws-vpc
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = ">= 4.0.0"
 
   name = "${local.prefix}-${local.vpc.name}"
   cidr = "10.10.0.0/16"

--- a/aws-modular/vpc.tf
+++ b/aws-modular/vpc.tf
@@ -2,7 +2,7 @@
 module "vpc" {
   count   = local.enable_eks ? 1 : 0
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = ">= 4.0.0"
 
   name = "${local.prefix}-${local.vpc.name}"
   cidr = "11.12.0.0/16"


### PR DESCRIPTION
The specified version for the terraform vpc provider in AWS stacks uses an older version

This causes issues later on when using deprecated parameters, namely the arguments "enable_classiclink" and "enable_classiclink_dns_support" are no longer used.

This caused the AWS stacks not to work, but with this change they do
