### PR TITLE
Fixing broken links after the docs update

### DIFF
--- a/aws-kubeflow-kserve/README.md
+++ b/aws-kubeflow-kserve/README.md
@@ -5,14 +5,14 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your pipelines after you execute this recipe 😍. It sets up the following resources: 
-- An EKS cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- An S3 bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
+- An EKS cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- An S3 bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
 
 Keep in mind, this is a basic setup to get you up and running on AWS with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀
 

--- a/aws-minimal/README.md
+++ b/aws-minimal/README.md
@@ -5,14 +5,14 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your pipelines after you execute this recipe 😍. It sets up the following resources: 
-- An EKS cluster that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- An S3 bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Seldon Core deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
+- An EKS cluster that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- An S3 bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Seldon Core deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
 
 Keep in mind, this is a basic setup to get you up and running on AWS with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀
 

--- a/aws-modular/README.md
+++ b/aws-modular/README.md
@@ -5,14 +5,14 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your pipelines after you execute this recipe 😍. It sets up the following resources: 
-- An EKS cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- An S3 bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
+- An EKS cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- An S3 bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
 
 Keep in mind, this is a basic setup to get you up and running on AWS with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀
 

--- a/aws-stores-minimal/README.md
+++ b/aws-stores-minimal/README.md
@@ -5,12 +5,12 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your pipelines after you execute this recipe 😍. It sets up the following resources: 
-- A local [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- An S3 bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing secrets for the metadata store. 
+- A local [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- An S3 bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing secrets for the metadata store. 
 
 Keep in mind, this is a basic setup to get you up and running on AWS with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀
 

--- a/azure-minimal/README.md
+++ b/azure-minimal/README.md
@@ -5,14 +5,14 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources: 
-- An AKS cluster that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- An Azure Blob Storage Container as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- An AKS cluster that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- An Azure Blob Storage Container as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
 - An Azure Container Registry instance for storing your docker images. 
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Seldon Core deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Seldon Core deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
 
 Keep in mind, this is a basic setup to get you up and running on GCP with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀
 

--- a/azureml-minimal/README.md
+++ b/azureml-minimal/README.md
@@ -5,12 +5,12 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further.
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further.
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources:
 
-- An Azure ML Workspace and cluster that can act as an [step operator](https://docs.zenml.io/user-guide/component-guide/step-operators) for your workloads.
-- An Azure Blob Storage Container as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc.
+- An Azure ML Workspace and cluster that can act as an [step operator](https://docs.zenml.io/stacks-and-components/component-guide/step-operators) for your workloads.
+- An Azure Blob Storage Container as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc.
 
 For each AzureML Worskpace, azureml automatically provisions a storage account, application insights, key vault, container registry and mlflow server.  
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,22 +24,10 @@ Here are a couple of example overviews from products with really great docs:
 [getting-started.md](overview/getting-started.md)
 {% endcontent-ref %}
 
-{% content-ref url="broken-reference" %}
-[Broken link](broken-reference)
-{% endcontent-ref %}
-
 ## Get Started
 
 We've put together some helpful guides for you to get setup with our product quickly and easily.
 
 {% content-ref url="fundamentals/how-it-works.md" %}
 [how-it-works.md](fundamentals/how-it-works.md)
-{% endcontent-ref %}
-
-{% content-ref url="broken-reference" %}
-[Broken link](broken-reference)
-{% endcontent-ref %}
-
-{% content-ref url="broken-reference" %}
-[Broken link](broken-reference)
 {% endcontent-ref %}

--- a/gcp-airflow/README.md
+++ b/gcp-airflow/README.md
@@ -5,12 +5,12 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources: 
-- A managed Airflow deployment on GCP using Cloud Composer as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- A GCS Bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
+- A managed Airflow deployment on GCP using Cloud Composer as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- A GCS Bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
 
 
 ## Prerequisites

--- a/gcp-kubeflow-kserve/README.md
+++ b/gcp-kubeflow-kserve/README.md
@@ -5,15 +5,15 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources: 
-- A GKE cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- A GCS Bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
-- Vertex AI is enabled which can be used a [step operator](https://docs.zenml.io/user-guide/component-guide/step-operators).
+- A GKE cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- A GCS Bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
+- Vertex AI is enabled which can be used a [step operator](https://docs.zenml.io/stacks-and-components/component-guide/step-operators).
 
 
 ## Prerequisites

--- a/gcp-minimal/README.md
+++ b/gcp-minimal/README.md
@@ -5,14 +5,14 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources: 
-- A GKE cluster that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- A GCS Bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Seldon Core deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
+- A GKE cluster that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- A GCS Bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Seldon Core deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
 
 Keep in mind, this is a basic setup to get you up and running on GCP with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀
 

--- a/gcp-modular/README.md
+++ b/gcp-modular/README.md
@@ -5,14 +5,14 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources: 
-- A GKE cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- A GCS Bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc.
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets.
+- A GKE cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- A GCS Bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc.
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets.
 - Vertex AI is enabled which can be used with a step operator or an orchestrator.
 
 

--- a/gcp-vertexai/README.md
+++ b/gcp-vertexai/README.md
@@ -5,15 +5,15 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources: 
-- A Vertex AI enabled workspace as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) that you can submit your pipelines to.
+- A Vertex AI enabled workspace as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) that you can submit your pipelines to.
 - A service account with all the necessary permissions needed to execute your pipelines.
-- A GCS bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- A Container Registry repository as [container registry](https://docs.zenml.io/user-guide/component-guide/container-registries) for hosting your docker images.
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
-- An optional MLflow Tracking server deployed on a GKE cluster as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers). 
+- A GCS bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- A Container Registry repository as [container registry](https://docs.zenml.io/stacks-and-components/component-guide/container-registries) for hosting your docker images.
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
+- An optional MLflow Tracking server deployed on a GKE cluster as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers). 
 
 
 Keep in mind, this is a basic setup to get you up and running on Vertex AI with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀

--- a/k3d-modular/README.md
+++ b/k3d-modular/README.md
@@ -5,20 +5,19 @@ VERSION OR USE THE `mlstacks` PACKAGE TO BENEFIT FROM LATEST UPDATES.**
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). In addition to that, we have created a local MLOps stack recipe that you can use to get started with your MLOps journey in a local environment 🤩.
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. In addition to that, we have created a local MLOps stack recipe that you can use to get started with your MLOps journey in a local environment 🤩.
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources:
-- A K3D cluster which you can use directly as [Kubernetes ZenML orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators/kubernetes) for your workloads.
-- A [local container registry](https://docs.zenml.io/user-guide/component-guide/container-registries/default) where container images built by your orchestrator are stored and used to run pipelines.
+- A K3D cluster which you can use directly as [Kubernetes ZenML orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators/kubernetes) for your workloads.
+- A [local container registry](https://docs.zenml.io/stacks-and-components/component-guide/container-registries/default) where container images built by your orchestrator are stored and used to run pipelines.
 
 In addition to the above, the following optional components can be enabled by setting various local variables to `true` in the `locals.tf` file:
 
-- set `minio.enable` to deploy a Minio S3 Bucket as an [S3 artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores/s3), which can be used to store all your ML artifacts like the model, checkpoints, etc. This is  implicitly included if you enable MLflow, because the MLflow tracking server needs it to store artifacts.
-- set `kubeflow.enable` to install Kubeflow and use it as a [Kubeflow orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators/kubeflow) in your ZenML stack.
-- set `mlflow.enable` to deploy an MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers/mlflow) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- you can deploy Tekton and use it as a [pipeline orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators/tekton) instead of or in addition to Kubeflow or the native ZenML Kubernetes orchestrator by setting `tekton.enable` to `true`.
-- to install and use Seldon as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers/seldon) in your ZenML pipelines, set `seldon.enable` to `true`.
-- to install and use KServe as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers/kserve) in your ZenML pipelines, set `kserve.enable` to `true`.
+- set `minio.enable` to deploy a Minio S3 Bucket as an [S3 artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores/s3), which can be used to store all your ML artifacts like the model, checkpoints, etc. This is  implicitly included if you enable MLflow, because the MLflow tracking server needs it to store artifacts.
+- set `kubeflow.enable` to install Kubeflow and use it as a [Kubeflow orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators/kubeflow) in your ZenML stack.
+- set `mlflow.enable` to deploy an MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers/mlflow) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- you can deploy Tekton and use it as a [pipeline orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators/tekton) instead of or in addition to Kubeflow or the native ZenML Kubernetes orchestrator by setting `tekton.enable` to `true`.
+- to install and use Seldon as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers/seldon) in your ZenML pipelines, set `seldon.enable` to `true`.
 
 Naturally, you can combine any of the stack component resources provisioned by this recipe with other local or remote ZenML stack components to create a custom MLOps stack that suits your needs.
 

--- a/src/mlstacks/terraform/aws-modular/README.md
+++ b/src/mlstacks/terraform/aws-modular/README.md
@@ -2,14 +2,14 @@
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your pipelines after you execute this recipe 😍. It sets up the following resources: 
-- An EKS cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- An S3 bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets. 
+- An EKS cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- An S3 bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc. 
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets. 
 
 Keep in mind, this is a basic setup to get you up and running on AWS with a minimal MLOps stack and more configuration options are coming in the form of new recipes! 👀
 

--- a/src/mlstacks/terraform/gcp-modular/README.md
+++ b/src/mlstacks/terraform/gcp-modular/README.md
@@ -2,14 +2,14 @@
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). This recipe, however, goes one step further. 
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. This recipe, however, goes one step further. 
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources: 
-- A GKE cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators) for your workloads.
-- A GCS Bucket as an [artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc.
-- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
-- A [secrets manager](https://docs.zenml.io/user-guide/component-guide/secrets-managers) enabled for storing your secrets.
+- A GKE cluster with Kubeflow installed that can act as an [orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators) for your workloads.
+- A GCS Bucket as an [artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores), which can be used to store all your ML artifacts like the model, checkpoints, etc.
+- An MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- A Kserve serverless deployment as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers) to have your trained model deployed on a Kubernetes cluster to run inference on. 
+- A [secrets manager](https://docs.zenml.io/stacks-and-components/component-guide/secrets-managers) enabled for storing your secrets.
 - Vertex AI is enabled which can be used with a step operator or an orchestrator.
 
 

--- a/src/mlstacks/terraform/k3d-modular/README.md
+++ b/src/mlstacks/terraform/k3d-modular/README.md
@@ -2,20 +2,19 @@
 
 There can be many motivations behind taking your ML application setup to a cloud environment, from needing specialized compute 💪 for training jobs to having a 24x7 load-balanced deployment of your trained model serving user requests 🚀.
 
-We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/platform-guide/set-up-your-mlops-platform/deploy-zenml) that takes you step-by-step through the entire journey in a cloud platform of your choice (AWS, GCP and Azure supported for now). In addition to that, we have created a local MLOps stack recipe that you can use to get started with your MLOps journey in a local environment 🤩.
+We know that the process to set up an MLOps stack can be daunting. There are many components (ever increasing) and each have their own requirements. To make your life easier, we already have a [documentation page](https://docs.zenml.io/user-guide/starter-guide/switch-to-production) that shows you different ways of switching to a production-grade setting. In addition to that, we have created a local MLOps stack recipe that you can use to get started with your MLOps journey in a local environment 🤩.
 
 You can have a simple MLOps stack ready for running your machine learning workloads after you execute this recipe 😍. It sets up the following resources:
-- A K3D cluster which you can use directly as [Kubernetes ZenML orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators/kubernetes) for your workloads.
-- A [local container registry](https://docs.zenml.io/user-guide/component-guide/container-registries/default) where container images built by your orchestrator are stored and used to run pipelines.
+- A K3D cluster which you can use directly as [Kubernetes ZenML orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators/kubernetes) for your workloads.
+- A [local container registry](https://docs.zenml.io/stacks-and-components/component-guide/container-registries/default) where container images built by your orchestrator are stored and used to run pipelines.
 
 In addition to the above, the following optional components can be enabled by setting various local variables to `true` in the `locals.tf` file:
 
-- set `minio.enable` to deploy a Minio S3 Bucket as an [S3 artifact store](https://docs.zenml.io/user-guide/component-guide/artifact-stores/s3), which can be used to store all your ML artifacts like the model, checkpoints, etc. This is  implicitly included if you enable MLflow, because the MLflow tracking server needs it to store artifacts.
-- set `kubeflow.enable` to install Kubeflow and use it as a [Kubeflow orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators/kubeflow) in your ZenML stack.
-- set `mlflow.enable` to deploy an MLflow tracking server as an [experiment tracker](https://docs.zenml.io/user-guide/component-guide/experiment-trackers/mlflow) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
-- you can deploy Tekton and use it as a [pipeline orchestrator](https://docs.zenml.io/user-guide/component-guide/orchestrators/tekton) instead of or in addition to Kubeflow or the native ZenML Kubernetes orchestrator by setting `tekton.enable` to `true`.
-- to install and use Seldon as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers/seldon) in your ZenML pipelines, set `seldon.enable` to `true`.
-- to install and use KServe as a [model deployer](https://docs.zenml.io/user-guide/component-guide/model-deployers/kserve) in your ZenML pipelines, set `kserve.enable` to `true`.
+- set `minio.enable` to deploy a Minio S3 Bucket as an [S3 artifact store](https://docs.zenml.io/stacks-and-components/component-guide/artifact-stores/s3), which can be used to store all your ML artifacts like the model, checkpoints, etc. This is  implicitly included if you enable MLflow, because the MLflow tracking server needs it to store artifacts.
+- set `kubeflow.enable` to install Kubeflow and use it as a [Kubeflow orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators/kubeflow) in your ZenML stack.
+- set `mlflow.enable` to deploy an MLflow tracking server as an [experiment tracker](https://docs.zenml.io/stacks-and-components/component-guide/experiment-trackers/mlflow) which can be used for logging data while running your applications. It also has a beautiful UI that you can use to view everything in one place.
+- you can deploy Tekton and use it as a [pipeline orchestrator](https://docs.zenml.io/stacks-and-components/component-guide/orchestrators/tekton) instead of or in addition to Kubeflow or the native ZenML Kubernetes orchestrator by setting `tekton.enable` to `true`.
+- to install and use Seldon as a [model deployer](https://docs.zenml.io/stacks-and-components/component-guide/model-deployers/seldon) in your ZenML pipelines, set `seldon.enable` to `true`.
 
 Naturally, you can combine any of the stack component resources provisioned by this recipe with other local or remote ZenML stack components to create a custom MLOps stack that suits your needs.
 


### PR DESCRIPTION
Additional points:
- I removed a few references to the KServe model deployer.
- I rephrased the link to the deployment documentation page.
- I removed some broken references in the docs README file.