### PR TITLE
Add deprecation warning for old HCL code

### DIFF
--- a/aws-kubeflow-kserve/aws_account.tf
+++ b/aws-kubeflow-kserve/aws_account.tf
@@ -1,2 +1,6 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # fetch the current account ID for use in container registry URL
 data "aws_caller_identity" "current" {}

--- a/aws-kubeflow-kserve/configure_docker.tf
+++ b/aws-kubeflow-kserve/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   provisioner "local-exec" {

--- a/aws-kubeflow-kserve/configure_kubectl.tf
+++ b/aws-kubeflow-kserve/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {

--- a/aws-kubeflow-kserve/ecr.tf
+++ b/aws-kubeflow-kserve/ecr.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # add an optional container registry
 resource "aws_ecr_repository" "zenml-ecr-repository" {
   name                 = local.ecr.name

--- a/aws-kubeflow-kserve/eks.tf
+++ b/aws-kubeflow-kserve/eks.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # eks module to create a cluster
 # newer versions of it had some error so going with v17.23.0 for now
 module "eks" {

--- a/aws-kubeflow-kserve/get_URIs.tf
+++ b/aws-kubeflow-kserve/get_URIs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # get URI for  MLflow tracking server
 data "kubernetes_service" "mlflow_tracking" {
   metadata {

--- a/aws-kubeflow-kserve/helm.tf
+++ b/aws-kubeflow-kserve/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/aws-kubeflow-kserve/kserve-module/cert_manager.tf
+++ b/aws-kubeflow-kserve/kserve-module/cert_manager.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a cert-manager release
 resource "helm_release" "cert-manager" {
   name       = "cert-manager"

--- a/aws-kubeflow-kserve/kserve-module/istio.tf
+++ b/aws-kubeflow-kserve/kserve-module/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up istio for kserve
 resource "null_resource" "create-istio-kserve" {
   provisioner "local-exec" {

--- a/aws-kubeflow-kserve/kserve-module/knative_serving.tf
+++ b/aws-kubeflow-kserve/kserve-module/knative_serving.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up istio for kserve
 resource "null_resource" "create-knative-serving" {
   provisioner "local-exec" {

--- a/aws-kubeflow-kserve/kserve-module/kserve.tf
+++ b/aws-kubeflow-kserve/kserve-module/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up istio for kserve
 resource "null_resource" "kserve" {
   provisioner "local-exec" {

--- a/aws-kubeflow-kserve/kserve-module/providers.tf
+++ b/aws-kubeflow-kserve/kserve-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/aws-kubeflow-kserve/kserve-module/variables.tf
+++ b/aws-kubeflow-kserve/kserve-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # namespace to create inference services in
 variable "workloads_namespace" {
   type    = string

--- a/aws-kubeflow-kserve/kserve.tf
+++ b/aws-kubeflow-kserve/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "kserve" {
   source = "./kserve-module"

--- a/aws-kubeflow-kserve/kubeflow.tf
+++ b/aws-kubeflow-kserve/kubeflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up kubeflow
 resource "null_resource" "kubeflow" {
   provisioner "local-exec" {

--- a/aws-kubeflow-kserve/kubernetes.tf
+++ b/aws-kubeflow-kserve/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {

--- a/aws-kubeflow-kserve/locals.tf
+++ b/aws-kubeflow-kserve/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "kflow"

--- a/aws-kubeflow-kserve/mlflow-module/README.md
+++ b/aws-kubeflow-kserve/mlflow-module/README.md
@@ -1,5 +1,8 @@
 # MLflow Terraform Module 
 
+**Deprecation warning:** this code and documentation has been deprecated. Please
+visit the corresponding location from `src/mlstacks/terraform` for the latest code and documentation.
+
 ## Input Variables
 
 Input | Description

--- a/aws-kubeflow-kserve/mlflow-module/ingress.tf
+++ b/aws-kubeflow-kserve/mlflow-module/ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up the nginx ingress controller and the ingress with basic auth
 
 resource "kubernetes_namespace" "nginx-ns" {

--- a/aws-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/aws-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the mlflow tracking server deployment
 resource "helm_release" "mlflow-tracking" {
 

--- a/aws-kubeflow-kserve/mlflow-module/output.tf
+++ b/aws-kubeflow-kserve/mlflow-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-controller-name" {
   value = helm_release.nginx-controller.name
 }

--- a/aws-kubeflow-kserve/mlflow-module/providers.tf
+++ b/aws-kubeflow-kserve/mlflow-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/aws-kubeflow-kserve/mlflow-module/secret.tf
+++ b/aws-kubeflow-kserve/mlflow-module/secret.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a secret with user credentials
 resource "kubernetes_secret" "name" {
   metadata {

--- a/aws-kubeflow-kserve/mlflow-module/variables.tf
+++ b/aws-kubeflow-kserve/mlflow-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "htpasswd" {}
 
 variable "kubernetes_sa" {

--- a/aws-kubeflow-kserve/mlflow.tf
+++ b/aws-kubeflow-kserve/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "./mlflow-module"

--- a/aws-kubeflow-kserve/output_file.tf
+++ b/aws-kubeflow-kserve/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/aws-kubeflow-kserve/outputs.tf
+++ b/aws-kubeflow-kserve/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # output for eks cluster
 output "eks-cluster-name" {
   value = data.aws_eks_cluster.cluster.name

--- a/aws-kubeflow-kserve/s3.tf
+++ b/aws-kubeflow-kserve/s3.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # creste s3 bucket for storing artifacts
 resource "aws_s3_bucket" "zenml-artifact-store" {
   bucket        = "${local.prefix}-${local.s3.name}"

--- a/aws-kubeflow-kserve/terraform.tf
+++ b/aws-kubeflow-kserve/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/aws-kubeflow-kserve/variables.tf
+++ b/aws-kubeflow-kserve/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for the MLflow tracking server
 variable "mlflow-artifact-S3-access-key" {
   description = "Your AWS access key for using S3 as MLflow artifact store"

--- a/aws-kubeflow-kserve/vpc.tf
+++ b/aws-kubeflow-kserve/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # VPC infra using https://github.com/terraform-aws-modules/terraform-aws-vpc
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/aws-minimal/.terraformignore
+++ b/aws-minimal/.terraformignore
@@ -1,0 +1,4 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+

--- a/aws-minimal/aws_account.tf
+++ b/aws-minimal/aws_account.tf
@@ -1,2 +1,6 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # fetch the current account ID for use in container registry URL
 data "aws_caller_identity" "current" {}

--- a/aws-minimal/configure_docker.tf
+++ b/aws-minimal/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   provisioner "local-exec" {

--- a/aws-minimal/configure_kubectl.tf
+++ b/aws-minimal/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {

--- a/aws-minimal/ecr.tf
+++ b/aws-minimal/ecr.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # add an optional container registry
 resource "aws_ecr_repository" "zenml-ecr-repository" {
   name                 = local.ecr.name

--- a/aws-minimal/eks.tf
+++ b/aws-minimal/eks.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # eks module to create a cluster
 # newer versions of it had some error so going with v17.23.0 for now
 module "eks" {

--- a/aws-minimal/get_URIs.tf
+++ b/aws-minimal/get_URIs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # get URI for  MLflow tracking server
 data "kubernetes_service" "mlflow_tracking" {
   metadata {

--- a/aws-minimal/helm.tf
+++ b/aws-minimal/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/aws-minimal/kubernetes.tf
+++ b/aws-minimal/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {

--- a/aws-minimal/locals.tf
+++ b/aws-minimal/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/aws-minimal/mlflow-module/ingress.tf
+++ b/aws-minimal/mlflow-module/ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up the nginx ingress controller and the ingress with basic auth
 
 resource "kubernetes_namespace" "nginx-ns" {

--- a/aws-minimal/mlflow-module/mlflow.tf
+++ b/aws-minimal/mlflow-module/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the mlflow tracking server deployment
 resource "helm_release" "mlflow-tracking" {
 

--- a/aws-minimal/mlflow-module/output.tf
+++ b/aws-minimal/mlflow-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-controller-name" {
   value = helm_release.nginx-controller.name
 }

--- a/aws-minimal/mlflow-module/providers.tf
+++ b/aws-minimal/mlflow-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/aws-minimal/mlflow-module/secret.tf
+++ b/aws-minimal/mlflow-module/secret.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a secret with user credentials
 resource "kubernetes_secret" "name" {
   metadata {

--- a/aws-minimal/mlflow-module/variables.tf
+++ b/aws-minimal/mlflow-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "htpasswd" {}
 
 variable "kubernetes_sa" {

--- a/aws-minimal/mlflow.tf
+++ b/aws-minimal/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "./mlflow-module"

--- a/aws-minimal/output_file.tf
+++ b/aws-minimal/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/aws-minimal/outputs.tf
+++ b/aws-minimal/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # output for eks cluster
 output "eks-cluster-name" {
   value = data.aws_eks_cluster.cluster.name

--- a/aws-minimal/s3.tf
+++ b/aws-minimal/s3.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # creste s3 bucket for storing artifacts
 resource "aws_s3_bucket" "zenml-artifact-store" {
   bucket        = "${local.prefix}-${local.s3.name}"

--- a/aws-minimal/seldon.tf
+++ b/aws-minimal/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the seldon module for creating a 
 # seldon + istio deployment
 module "seldon" {

--- a/aws-minimal/seldon/istio.tf
+++ b/aws-minimal/seldon/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a namespace for istio resources
 resource "kubernetes_namespace" "istio-ns" {
   metadata {

--- a/aws-minimal/seldon/outputs.tf
+++ b/aws-minimal/seldon/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-gateway-spec" {
   value = kubectl_manifest.gateway.live_manifest_incluster
 }

--- a/aws-minimal/seldon/providers.tf
+++ b/aws-minimal/seldon/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the seldon module
 terraform {
   required_providers {

--- a/aws-minimal/seldon/seldon.tf
+++ b/aws-minimal/seldon/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # creating the namespace for the seldon deployment
 resource "kubernetes_namespace" "seldon-ns" {
   metadata {

--- a/aws-minimal/seldon/variables.tf
+++ b/aws-minimal/seldon/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables are values that should be supplied 
 # by the calling module
 

--- a/aws-minimal/terraform.tf
+++ b/aws-minimal/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/aws-minimal/variables.tf
+++ b/aws-minimal/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for the MLflow tracking server
 variable "mlflow-artifact-S3-access-key" {
   description = "Your AWS access key for using S3 as MLflow artifact store"

--- a/aws-minimal/vpc.tf
+++ b/aws-minimal/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # VPC infra using https://github.com/terraform-aws-modules/terraform-aws-vpc
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/aws-modular/aws_account.tf
+++ b/aws-modular/aws_account.tf
@@ -1,2 +1,6 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # fetch the current account ID for use in container registry URL
 data "aws_caller_identity" "current" {}

--- a/aws-modular/cert_manager.tf
+++ b/aws-modular/cert_manager.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the cert-manager module to create a cert-manager deployment
 module "cert-manager" {
   source = "../modules/cert-manager-module"

--- a/aws-modular/configure_docker.tf
+++ b/aws-modular/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   count = var.enable_container_registry ? 1 : 0

--- a/aws-modular/configure_kubectl.tf
+++ b/aws-modular/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   count = length(aws_eks_cluster.cluster) > 0 ? 1 : 0

--- a/aws-modular/ecr.tf
+++ b/aws-modular/ecr.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # add an optional container registry
 resource "aws_ecr_repository" "zenml-ecr-repository" {
   count                = var.enable_container_registry ? 1 : 0

--- a/aws-modular/eks.tf
+++ b/aws-modular/eks.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # eks module to create a cluster
 # newer versions of it had some error so going with v17.23.0 for now
 locals {

--- a/aws-modular/helm.tf
+++ b/aws-modular/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/aws-modular/istio.tf
+++ b/aws-modular/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "istio" {
   source = "../modules/istio-module"

--- a/aws-modular/kserve.tf
+++ b/aws-modular/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "kserve" {
   source = "../modules/kserve-module"

--- a/aws-modular/kubeflow.tf
+++ b/aws-modular/kubeflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the kubeflow pipelines module to create a kubeflow pipelines deployment
 module "kubeflow-pipelines" {
   source = "../modules/kubeflow-pipelines-module"

--- a/aws-modular/kubernetes.tf
+++ b/aws-modular/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {

--- a/aws-modular/locals.tf
+++ b/aws-modular/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "random_string" "unique" {
   length  = 4
   special = false

--- a/aws-modular/mlflow.tf
+++ b/aws-modular/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "../modules/mlflow-module"

--- a/aws-modular/nginx_ingress.tf
+++ b/aws-modular/nginx_ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the nginx-ingress module to create an nginx-ingress deployment
 module "nginx-ingress" {
   source = "../modules/nginx-ingress-module"

--- a/aws-modular/output_file.tf
+++ b/aws-modular/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/aws-modular/outputs.tf
+++ b/aws-modular/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # output for eks cluster
 output "eks-cluster-name" {
   value = local.enable_eks ? "${local.prefix}-${local.eks.cluster_name}" : ""

--- a/aws-modular/s3.tf
+++ b/aws-modular/s3.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create s3 bucket for storing artifacts
 resource "aws_s3_bucket" "zenml-artifact-store" {
   count         = var.enable_artifact_store ? 1 : 0

--- a/aws-modular/sagemaker.tf
+++ b/aws-modular/sagemaker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Create an IAM role for SageMaker
 resource "aws_iam_role" "sagemaker_role" {
   count              = var.enable_orchestrator_sagemaker || var.enable_step_operator_sagemaker ? 1 : 0

--- a/aws-modular/seldon.tf
+++ b/aws-modular/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the seldon module for creating a 
 # seldon + istio deployment
 module "seldon" {

--- a/aws-modular/tekton.tf
+++ b/aws-modular/tekton.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the tekton pipelines module to create a tekton pipelines deployment
 module "tekton-pipelines" {
   source = "../modules/tekton-pipelines-module"

--- a/aws-modular/terraform.tf
+++ b/aws-modular/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/aws-modular/variables.tf
+++ b/aws-modular/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # enable services
 variable "enable_artifact_store" {
   description = "Enable S3 deployment"

--- a/aws-modular/vpc.tf
+++ b/aws-modular/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # VPC infra using https://github.com/terraform-aws-modules/terraform-aws-vpc
 module "vpc" {
   count   = local.enable_eks ? 1 : 0

--- a/aws-modular/zenml.tf
+++ b/aws-modular/zenml.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the zenml module to create a zenml deployment
 module "zenml" {
   source = "../modules/zenml-module"

--- a/aws-stores-minimal/aws_account.tf
+++ b/aws-stores-minimal/aws_account.tf
@@ -1,2 +1,6 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # fetch the current account ID for use in container registry URL
 data "aws_caller_identity" "current" {}

--- a/aws-stores-minimal/ecr.tf
+++ b/aws-stores-minimal/ecr.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # add an optional container registry
 resource "aws_ecr_repository" "zenml-ecr-repository" {
   name                 = local.ecr.name

--- a/aws-stores-minimal/locals.tf
+++ b/aws-stores-minimal/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/aws-stores-minimal/output_file.tf
+++ b/aws-stores-minimal/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/aws-stores-minimal/outputs.tf
+++ b/aws-stores-minimal/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # output for s3 bucket
 output "s3-bucket-path" {
   value       = "s3://${aws_s3_bucket.zenml-artifact-store.bucket}"

--- a/aws-stores-minimal/s3.tf
+++ b/aws-stores-minimal/s3.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # creste s3 bucket for storing artifacts
 resource "aws_s3_bucket" "zenml-artifact-store" {
   bucket        = "${local.prefix}-${local.s3.name}"

--- a/aws-stores-minimal/terraform.tf
+++ b/aws-stores-minimal/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/aws-stores-minimal/variables.tf
+++ b/aws-stores-minimal/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"

--- a/azure-minimal/aks.tf
+++ b/azure-minimal/aks.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "azurerm_kubernetes_cluster" "cluster" {
   name                = azurerm_kubernetes_cluster.aks.name
   resource_group_name = azurerm_resource_group.rg.name

--- a/azure-minimal/blob_storage.tf
+++ b/azure-minimal/blob_storage.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "azurerm_storage_account" "zenml-account" {
   name                     = "${local.prefix}${local.blob_storage.account_name}"
   resource_group_name      = azurerm_resource_group.rg.name

--- a/azure-minimal/configure_docker.tf
+++ b/azure-minimal/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   provisioner "local-exec" {

--- a/azure-minimal/configure_kubectl.tf
+++ b/azure-minimal/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {

--- a/azure-minimal/container_registry.tf
+++ b/azure-minimal/container_registry.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "azurerm_container_registry" "container_registry" {
   name                = "${local.prefix}${local.acr.name}"
   resource_group_name = azurerm_resource_group.rg.name

--- a/azure-minimal/get_URIs.tf
+++ b/azure-minimal/get_URIs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # get URI for  MLflow tracking server
 data "kubernetes_service" "mlflow_tracking" {
   metadata {

--- a/azure-minimal/helm.tf
+++ b/azure-minimal/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/azure-minimal/key_vault.tf
+++ b/azure-minimal/key_vault.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "azurerm_client_config" "current" {}
 
 # create a key vault instance that can be used for storing secrets

--- a/azure-minimal/kubernetes.tf
+++ b/azure-minimal/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 provider "kubernetes" {
   host = data.azurerm_kubernetes_cluster.cluster.kube_config.0.host

--- a/azure-minimal/locals.tf
+++ b/azure-minimal/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/azure-minimal/mlflow-module/ingress.tf
+++ b/azure-minimal/mlflow-module/ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up the nginx ingress controller and the ingress with basic auth
 
 resource "kubernetes_namespace" "nginx-ns" {

--- a/azure-minimal/mlflow-module/mlflow.tf
+++ b/azure-minimal/mlflow-module/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the mlflow tracking server deployment
 resource "helm_release" "mlflow-tracking" {
 

--- a/azure-minimal/mlflow-module/output.tf
+++ b/azure-minimal/mlflow-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-controller-name" {
   value = helm_release.nginx-controller.name
 }

--- a/azure-minimal/mlflow-module/providers.tf
+++ b/azure-minimal/mlflow-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/azure-minimal/mlflow-module/secret.tf
+++ b/azure-minimal/mlflow-module/secret.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a secret with user credentials
 resource "kubernetes_secret" "name" {
   metadata {

--- a/azure-minimal/mlflow-module/variables.tf
+++ b/azure-minimal/mlflow-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "htpasswd" {}
 
 variable "kubernetes_sa" {

--- a/azure-minimal/mlflow.tf
+++ b/azure-minimal/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "./mlflow-module"

--- a/azure-minimal/output_file.tf
+++ b/azure-minimal/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/azure-minimal/outputs.tf
+++ b/azure-minimal/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Resource Group
 output "resource-group-name" {
   value = azurerm_resource_group.rg.name

--- a/azure-minimal/rg.tf
+++ b/azure-minimal/rg.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "azurerm_resource_group" "rg" {
   name     = "${local.prefix}-${local.resource_group.name}"
   location = local.resource_group.location

--- a/azure-minimal/seldon.tf
+++ b/azure-minimal/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the seldon module for creating a 
 # seldon + istio deployment
 module "seldon" {

--- a/azure-minimal/seldon/istio.tf
+++ b/azure-minimal/seldon/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a namespace for istio resources
 resource "kubernetes_namespace" "istio-ns" {
   metadata {

--- a/azure-minimal/seldon/outputs.tf
+++ b/azure-minimal/seldon/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-gateway-spec" {
   value = kubectl_manifest.gateway.live_manifest_incluster
 }

--- a/azure-minimal/seldon/providers.tf
+++ b/azure-minimal/seldon/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the seldon module
 terraform {
   required_providers {

--- a/azure-minimal/seldon/seldon.tf
+++ b/azure-minimal/seldon/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # creating the namespace for the seldon deployment
 resource "kubernetes_namespace" "seldon-ns" {
   metadata {

--- a/azure-minimal/seldon/variables.tf
+++ b/azure-minimal/seldon/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables are values that should be supplied 
 # by the calling module
 

--- a/azure-minimal/terraform.tf
+++ b/azure-minimal/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/azure-minimal/variables.tf
+++ b/azure-minimal/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for the MLflow tracking server
 variable "mlflow-username" {
   description = "The username for the MLflow Tracking Server"

--- a/azure-minimal/vpc.tf
+++ b/azure-minimal/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 module "network" {
   source              = "Azure/network/azurerm"
   version             = "3.5.0"

--- a/azureml-minimal/access_policy.tf
+++ b/azureml-minimal/access_policy.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a access role based on service principal created in compute cluster
 data "azurerm_client_config" "config" {
   depends_on = [

--- a/azureml-minimal/blob_storage.tf
+++ b/azureml-minimal/blob_storage.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 
 # workspace storage account
 resource "azurerm_storage_account" "zenml-account" {

--- a/azureml-minimal/cluster.tf
+++ b/azureml-minimal/cluster.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "azurerm_client_config" "current" {
   depends_on = [azurerm_resource_group.rg]
 

--- a/azureml-minimal/key_vault.tf
+++ b/azureml-minimal/key_vault.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # workspace keyvault
 resource "azurerm_key_vault" "secret_manager" {
   name                        = local.key_vault.name

--- a/azureml-minimal/locals.tf
+++ b/azureml-minimal/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/azureml-minimal/output_file.tf
+++ b/azureml-minimal/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/azureml-minimal/outputs.tf
+++ b/azureml-minimal/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # subscription id
 output "subscription-id" {
   value     = data.azurerm_client_config.current.subscription_id

--- a/azureml-minimal/rg.tf
+++ b/azureml-minimal/rg.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "azurerm_resource_group" "rg" {
   name     = "${local.prefix}-${local.resource_group.name}"
   location = local.resource_group.location

--- a/azureml-minimal/service_principal.tf
+++ b/azureml-minimal/service_principal.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "azuread_application" "app" {
   display_name = "azure-zenml-app"
 }

--- a/azureml-minimal/terraform.tf
+++ b/azureml-minimal/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/azureml-minimal/variables.tf
+++ b/azureml-minimal/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"

--- a/gcp-airflow/composer.tf
+++ b/gcp-airflow/composer.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "google_project" "project" {
   project_id = local.project_id
 }

--- a/gcp-airflow/configure_docker.tf
+++ b/gcp-airflow/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   provisioner "local-exec" {

--- a/gcp-airflow/configure_kubectl.tf
+++ b/gcp-airflow/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {

--- a/gcp-airflow/enable_services.tf
+++ b/gcp-airflow/enable_services.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # You must have owner, editor, or service config editor roles 
 # to be able to enable services.
 

--- a/gcp-airflow/gcs.tf
+++ b/gcp-airflow/gcs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "google_storage_bucket" "artifact-store" {
   name     = "${local.prefix}-${local.gcs.name}"
   project  = local.project_id

--- a/gcp-airflow/locals.tf
+++ b/gcp-airflow/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/gcp-airflow/output_file.tf
+++ b/gcp-airflow/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/gcp-airflow/outputs.tf
+++ b/gcp-airflow/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # project id
 output "project-id" {
   value = local.project_id

--- a/gcp-airflow/terraform.tf
+++ b/gcp-airflow/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/gcp-airflow/variables.tf
+++ b/gcp-airflow/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for creating a ZenML stack configuration file
 variable "zenml-version" {
   description = "The version of ZenML being used"

--- a/gcp-kubeflow-kserve/configure_docker.tf
+++ b/gcp-kubeflow-kserve/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   provisioner "local-exec" {

--- a/gcp-kubeflow-kserve/configure_kubectl.tf
+++ b/gcp-kubeflow-kserve/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {

--- a/gcp-kubeflow-kserve/enable_services.tf
+++ b/gcp-kubeflow-kserve/enable_services.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # You must have owner, editor, or service config editor roles 
 # to be able to enable services.
 

--- a/gcp-kubeflow-kserve/gcs.tf
+++ b/gcp-kubeflow-kserve/gcs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "google_storage_bucket" "artifact-store" {
   name     = "${local.prefix}-${local.gcs.name}"
   project  = local.project_id

--- a/gcp-kubeflow-kserve/get_URIs.tf
+++ b/gcp-kubeflow-kserve/get_URIs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # get URI for  MLflow tracking server
 data "kubernetes_service" "mlflow_tracking" {
   metadata {

--- a/gcp-kubeflow-kserve/gke.tf
+++ b/gcp-kubeflow-kserve/gke.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "google_client_config" "default" {}
 module "gke" {
   depends_on = [

--- a/gcp-kubeflow-kserve/helm.tf
+++ b/gcp-kubeflow-kserve/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/gcp-kubeflow-kserve/kserve-module/cert_manager.tf
+++ b/gcp-kubeflow-kserve/kserve-module/cert_manager.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a cert-manager release
 resource "helm_release" "cert-manager" {
   name       = "cert-manager"

--- a/gcp-kubeflow-kserve/kserve-module/istio.tf
+++ b/gcp-kubeflow-kserve/kserve-module/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up istio for kserve
 resource "null_resource" "create-istio-kserve" {
   provisioner "local-exec" {

--- a/gcp-kubeflow-kserve/kserve-module/knative_serving.tf
+++ b/gcp-kubeflow-kserve/kserve-module/knative_serving.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up istio for kserve
 resource "null_resource" "create-knative-serving" {
   provisioner "local-exec" {

--- a/gcp-kubeflow-kserve/kserve-module/kserve.tf
+++ b/gcp-kubeflow-kserve/kserve-module/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up istio for kserve
 resource "null_resource" "kserve" {
   provisioner "local-exec" {

--- a/gcp-kubeflow-kserve/kserve-module/providers.tf
+++ b/gcp-kubeflow-kserve/kserve-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/gcp-kubeflow-kserve/kserve-module/variables.tf
+++ b/gcp-kubeflow-kserve/kserve-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # namespace to create inference services in
 variable "workloads_namespace" {
   type    = string

--- a/gcp-kubeflow-kserve/kserve.tf
+++ b/gcp-kubeflow-kserve/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "kserve" {
   source = "./kserve-module"

--- a/gcp-kubeflow-kserve/kubeflow.tf
+++ b/gcp-kubeflow-kserve/kubeflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up kubeflow
 resource "null_resource" "kubeflow" {
   provisioner "local-exec" {

--- a/gcp-kubeflow-kserve/kubernetes.tf
+++ b/gcp-kubeflow-kserve/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {

--- a/gcp-kubeflow-kserve/locals.tf
+++ b/gcp-kubeflow-kserve/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/gcp-kubeflow-kserve/mlflow-module/ingress.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up the nginx ingress controller and the ingress with basic auth
 
 resource "kubernetes_namespace" "nginx-ns" {

--- a/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the mlflow tracking server deployment
 resource "helm_release" "mlflow-tracking" {
 

--- a/gcp-kubeflow-kserve/mlflow-module/output.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-controller-name" {
   value = helm_release.nginx-controller.name
 }

--- a/gcp-kubeflow-kserve/mlflow-module/providers.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/gcp-kubeflow-kserve/mlflow-module/secret.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/secret.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a secret with user credentials
 resource "kubernetes_secret" "name" {
   metadata {

--- a/gcp-kubeflow-kserve/mlflow-module/variables.tf
+++ b/gcp-kubeflow-kserve/mlflow-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "htpasswd" {}
 
 variable "kubernetes_sa" {

--- a/gcp-kubeflow-kserve/mlflow.tf
+++ b/gcp-kubeflow-kserve/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "./mlflow-module"

--- a/gcp-kubeflow-kserve/output_file.tf
+++ b/gcp-kubeflow-kserve/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/gcp-kubeflow-kserve/outputs.tf
+++ b/gcp-kubeflow-kserve/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # project id
 output "project-id" {
   value = local.project_id

--- a/gcp-kubeflow-kserve/terraform.tf
+++ b/gcp-kubeflow-kserve/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/gcp-kubeflow-kserve/variables.tf
+++ b/gcp-kubeflow-kserve/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for the MLflow tracking server
 variable "mlflow-username" {
   description = "The username for the MLflow Tracking Server"

--- a/gcp-kubeflow-kserve/vpc.tf
+++ b/gcp-kubeflow-kserve/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 module "vpc" {
   source  = "terraform-google-modules/network/google"
   version = "~> 4.0"

--- a/gcp-minimal/artifact_repository.tf
+++ b/gcp-minimal/artifact_repository.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # # add an optional artifact repository
 # resource "google_artifact_registry_repository" "artifact-repository" {
 #   provider = google-beta

--- a/gcp-minimal/configure_docker.tf
+++ b/gcp-minimal/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   provisioner "local-exec" {

--- a/gcp-minimal/configure_kubectl.tf
+++ b/gcp-minimal/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   provisioner "local-exec" {

--- a/gcp-minimal/enable_services.tf
+++ b/gcp-minimal/enable_services.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # You must have owner, editor, or service config editor roles 
 # to be able to enable services.
 

--- a/gcp-minimal/gcs.tf
+++ b/gcp-minimal/gcs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "google_storage_bucket" "artifact-store" {
   name     = "${local.prefix}-${local.gcs.name}"
   project  = local.project_id

--- a/gcp-minimal/get_URIs.tf
+++ b/gcp-minimal/get_URIs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # get URI for  MLflow tracking server
 data "kubernetes_service" "mlflow_tracking" {
   metadata {

--- a/gcp-minimal/gke.tf
+++ b/gcp-minimal/gke.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "google_client_config" "default" {}
 module "gke" {
   depends_on = [

--- a/gcp-minimal/helm.tf
+++ b/gcp-minimal/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/gcp-minimal/kubernetes.tf
+++ b/gcp-minimal/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {

--- a/gcp-minimal/locals.tf
+++ b/gcp-minimal/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/gcp-minimal/mlflow-module/ingress.tf
+++ b/gcp-minimal/mlflow-module/ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up the nginx ingress controller and the ingress with basic auth
 
 resource "kubernetes_namespace" "nginx-ns" {

--- a/gcp-minimal/mlflow-module/mlflow.tf
+++ b/gcp-minimal/mlflow-module/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the mlflow tracking server deployment
 resource "helm_release" "mlflow-tracking" {
 

--- a/gcp-minimal/mlflow-module/output.tf
+++ b/gcp-minimal/mlflow-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-controller-name" {
   value = helm_release.nginx-controller.name
 }

--- a/gcp-minimal/mlflow-module/providers.tf
+++ b/gcp-minimal/mlflow-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/gcp-minimal/mlflow-module/secret.tf
+++ b/gcp-minimal/mlflow-module/secret.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a secret with user credentials
 resource "kubernetes_secret" "name" {
   metadata {

--- a/gcp-minimal/mlflow-module/variables.tf
+++ b/gcp-minimal/mlflow-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "htpasswd" {}
 
 variable "kubernetes_sa" {

--- a/gcp-minimal/mlflow.tf
+++ b/gcp-minimal/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "./mlflow-module"

--- a/gcp-minimal/output_file.tf
+++ b/gcp-minimal/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/gcp-minimal/outputs.tf
+++ b/gcp-minimal/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # project id
 output "project-id" {
   value = local.project_id

--- a/gcp-minimal/seldon.tf
+++ b/gcp-minimal/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the seldon module for creating a 
 # seldon + istio deployment
 module "seldon" {

--- a/gcp-minimal/seldon/istio.tf
+++ b/gcp-minimal/seldon/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a namespace for istio resources
 resource "kubernetes_namespace" "istio-ns" {
   metadata {

--- a/gcp-minimal/seldon/outputs.tf
+++ b/gcp-minimal/seldon/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-gateway-spec" {
   value = kubectl_manifest.gateway.live_manifest_incluster
 }

--- a/gcp-minimal/seldon/providers.tf
+++ b/gcp-minimal/seldon/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the seldon module
 terraform {
   required_providers {

--- a/gcp-minimal/seldon/seldon.tf
+++ b/gcp-minimal/seldon/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # creating the namespace for the seldon deployment
 resource "kubernetes_namespace" "seldon-ns" {
   metadata {

--- a/gcp-minimal/seldon/variables.tf
+++ b/gcp-minimal/seldon/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables are values that should be supplied 
 # by the calling module
 

--- a/gcp-minimal/terraform.tf
+++ b/gcp-minimal/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/gcp-minimal/variables.tf
+++ b/gcp-minimal/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for the MLflow tracking server
 variable "mlflow-username" {
   description = "The username for the MLflow Tracking Server"

--- a/gcp-minimal/vpc.tf
+++ b/gcp-minimal/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 module "vpc" {
   source  = "terraform-google-modules/network/google"
   version = "~> 4.0"

--- a/gcp-modular/cert_manager.tf
+++ b/gcp-modular/cert_manager.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the cert-manager module to create a cert-manager deployment
 module "cert-manager" {
   source = "../modules/cert-manager-module"

--- a/gcp-modular/configure_docker.tf
+++ b/gcp-modular/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   count = var.enable_container_registry ? 1 : 0

--- a/gcp-modular/configure_kubectl.tf
+++ b/gcp-modular/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   count = length(google_container_cluster.gke) > 0 ? 1 : 0

--- a/gcp-modular/enable_services.tf
+++ b/gcp-modular/enable_services.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "google_project" "project" {
   count      = local.enable_vertex ? 1 : 0
   project_id = var.project_id

--- a/gcp-modular/gcs.tf
+++ b/gcp-modular/gcs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "google_storage_bucket" "artifact-store" {
   count    = var.enable_artifact_store ? 1 : 0
   name     = "${local.prefix}-${local.gcs.name}"

--- a/gcp-modular/gke.tf
+++ b/gcp-modular/gke.tf
@@ -1,3 +1,8 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
+
 data "google_client_config" "default" {}
 # module "gke" {
 #   count = (var.enable_orchestrator_kubeflow || var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes || 

--- a/gcp-modular/helm.tf
+++ b/gcp-modular/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/gcp-modular/istio.tf
+++ b/gcp-modular/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "istio" {
   source = "../modules/istio-module"

--- a/gcp-modular/kserve.tf
+++ b/gcp-modular/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "kserve" {
   source = "../modules/kserve-module"

--- a/gcp-modular/kubeflow.tf
+++ b/gcp-modular/kubeflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the kubeflow pipelines module to create a kubeflow pipelines deployment
 module "kubeflow-pipelines" {
   source = "../modules/kubeflow-pipelines-module"

--- a/gcp-modular/kubernetes.tf
+++ b/gcp-modular/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {

--- a/gcp-modular/locals.tf
+++ b/gcp-modular/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "random_string" "unique" {
   length  = 4
   special = false

--- a/gcp-modular/mlflow.tf
+++ b/gcp-modular/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "../modules/mlflow-module"

--- a/gcp-modular/nginx_ingress.tf
+++ b/gcp-modular/nginx_ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the nginx-ingress module to create an nginx-ingress deployment
 module "nginx-ingress" {
   source = "../modules/nginx-ingress-module"

--- a/gcp-modular/output_file.tf
+++ b/gcp-modular/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/gcp-modular/outputs.tf
+++ b/gcp-modular/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # if gcs is enabled, set the artifact store outputs to the gcs values
 # otherwise, set the artifact store outputs to empty strings
 output "artifact_store_id" {

--- a/gcp-modular/seldon.tf
+++ b/gcp-modular/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the seldon module for creating a 
 # seldon + istio deployment
 module "seldon" {

--- a/gcp-modular/tekton.tf
+++ b/gcp-modular/tekton.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the tekton pipelines module to create a tekton pipelines deployment
 module "tekton-pipelines" {
   source = "../modules/tekton-pipelines-module"

--- a/gcp-modular/terraform.tf
+++ b/gcp-modular/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/gcp-modular/variables.tf
+++ b/gcp-modular/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # enable services
 variable "enable_artifact_store" {
   description = "Enable GCS deployment"

--- a/gcp-modular/vertex.tf
+++ b/gcp-modular/vertex.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 locals {
   enable_vertex = (var.enable_step_operator_vertex || var.enable_orchestrator_vertex)
 }

--- a/gcp-modular/vpc.tf
+++ b/gcp-modular/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 module "vpc" {
   count = (var.enable_orchestrator_kubeflow || var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
     var.enable_model_deployer_kserve || var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow ||

--- a/gcp-modular/zenml.tf
+++ b/gcp-modular/zenml.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the zenml module to create a zenml deployment
 module "zenml" {
   source = "../modules/zenml-module"

--- a/gcp-vertexai/configure_docker.tf
+++ b/gcp-vertexai/configure_docker.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local docker client to access the newly created registry
 resource "null_resource" "configure-local-docker" {
   provisioner "local-exec" {

--- a/gcp-vertexai/configure_kubectl.tf
+++ b/gcp-vertexai/configure_kubectl.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up local kubectl client to access the newly created cluster
 resource "null_resource" "configure-local-kubectl" {
   count = var.enable_mlflow ? 1 : 0

--- a/gcp-vertexai/container_repository.tf
+++ b/gcp-vertexai/container_repository.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # add an optional artifact repository
 # resource "google_artifact_registry_repository" "artifact-repository" {
 #   provider = google-beta

--- a/gcp-vertexai/enable_services.tf
+++ b/gcp-vertexai/enable_services.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "google_project" "project" {
   project_id = local.project_id
 }

--- a/gcp-vertexai/gcs.tf
+++ b/gcp-vertexai/gcs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "google_storage_bucket" "artifact-store" {
   name     = "${local.prefix}-${local.gcs.name}"
   project  = local.project_id

--- a/gcp-vertexai/get_URIs.tf
+++ b/gcp-vertexai/get_URIs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # get URI for  MLflow tracking server
 data "kubernetes_service" "mlflow_tracking" {
   count = var.enable_mlflow ? 1 : 0

--- a/gcp-vertexai/gke.tf
+++ b/gcp-vertexai/gke.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 data "google_client_config" "default" {}
 
 module "gke" {

--- a/gcp-vertexai/helm.tf
+++ b/gcp-vertexai/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/gcp-vertexai/kubernetes.tf
+++ b/gcp-vertexai/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 # not defining the kubernetes provider throws an error while running the eks module
 provider "kubernetes" {

--- a/gcp-vertexai/locals.tf
+++ b/gcp-vertexai/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   prefix = "demo"

--- a/gcp-vertexai/mlflow-module/ingress.tf
+++ b/gcp-vertexai/mlflow-module/ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up the nginx ingress controller and the ingress with basic auth
 
 resource "kubernetes_namespace" "nginx-ns" {

--- a/gcp-vertexai/mlflow-module/mlflow.tf
+++ b/gcp-vertexai/mlflow-module/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the mlflow tracking server deployment
 resource "helm_release" "mlflow-tracking" {
 

--- a/gcp-vertexai/mlflow-module/output.tf
+++ b/gcp-vertexai/mlflow-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-controller-name" {
   value = helm_release.nginx-controller.name
 }

--- a/gcp-vertexai/mlflow-module/providers.tf
+++ b/gcp-vertexai/mlflow-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/gcp-vertexai/mlflow-module/secret.tf
+++ b/gcp-vertexai/mlflow-module/secret.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a secret with user credentials
 resource "kubernetes_secret" "name" {
   metadata {

--- a/gcp-vertexai/mlflow-module/variables.tf
+++ b/gcp-vertexai/mlflow-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "htpasswd" {}
 
 variable "kubernetes_sa" {

--- a/gcp-vertexai/mlflow.tf
+++ b/gcp-vertexai/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "./mlflow-module"

--- a/gcp-vertexai/output_file.tf
+++ b/gcp-vertexai/output_file.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file_mlflow" {

--- a/gcp-vertexai/outputs.tf
+++ b/gcp-vertexai/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # project number
 output "project-number" {
   value       = data.google_project.project.number

--- a/gcp-vertexai/terraform.tf
+++ b/gcp-vertexai/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/gcp-vertexai/variables.tf
+++ b/gcp-vertexai/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # variables for the MLflow tracking server
 variable "enable_mlflow" {
   description = "Whether to deploy MLflow"

--- a/gcp-vertexai/vertex.tf
+++ b/gcp-vertexai/vertex.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # workload service account for Vertex pipelines
 resource "google_service_account" "sa" {
   account_id   = "${local.prefix}-${local.service_account.account_id}"

--- a/gcp-vertexai/vpc.tf
+++ b/gcp-vertexai/vpc.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 module "vpc" {
   depends_on = [
     google_project_service.compute_engine_api

--- a/k3d-modular/helm.tf
+++ b/k3d-modular/helm.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # A default (non-aliased) provider configuration for "helm"
 provider "helm" {
   kubernetes {

--- a/k3d-modular/istio.tf
+++ b/k3d-modular/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "istio" {
   source = "../modules/istio-module"

--- a/k3d-modular/k3d.tf
+++ b/k3d-modular/k3d.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "random_string" "cluster_id" {
   length  = 6
   special = false

--- a/k3d-modular/kserve.tf
+++ b/k3d-modular/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create kserve module
 module "kserve" {
   source = "../modules/kserve-module"

--- a/k3d-modular/kubeflow.tf
+++ b/k3d-modular/kubeflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the kubeflow pipelines module to create a kubeflow pipelines deployment
 module "kubeflow-pipelines" {
   source = "../modules/kubeflow-pipelines-module"

--- a/k3d-modular/kubernetes.tf
+++ b/k3d-modular/kubernetes.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # a default (non-aliased) provider configuration for "kubernetes"
 provider "kubernetes" {
   host = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||

--- a/k3d-modular/locals.tf
+++ b/k3d-modular/locals.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # config values to use across the module
 locals {
   k3d = {

--- a/k3d-modular/minio.tf
+++ b/k3d-modular/minio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 locals {
   enable_minio = (var.enable_artifact_store || var.enable_experiment_tracker_mlflow)
 }

--- a/k3d-modular/mlflow.tf
+++ b/k3d-modular/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the mlflow module to create an mlflow deployment
 module "mlflow" {
   source = "../modules/mlflow-module"

--- a/k3d-modular/nginx_ingress.tf
+++ b/k3d-modular/nginx_ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the nginx-ingress module to create an nginx-ingress deployment
 module "nginx-ingress" {
   source = "../modules/nginx-ingress-module"

--- a/k3d-modular/output_stack.tf
+++ b/k3d-modular/output_stack.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a stack yaml file 
 # that can be consumed by zenml stack import
 resource "local_file" "stack_file" {

--- a/k3d-modular/output_test_harness_cfg.tf
+++ b/k3d-modular/output_test_harness_cfg.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Export Terraform output variable values to a ZenML test framework
 # configuration file that can be used to run ZenML integration tests
 # against the deployed MLOps stack.

--- a/k3d-modular/outputs.tf
+++ b/k3d-modular/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # if minio is enabled, set the artifact store outputs to the minio values
 # otherwise, set the artifact store outputs to empty strings
 output "artifact_store_id" {

--- a/k3d-modular/seldon.tf
+++ b/k3d-modular/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the seldon module for creating a 
 # seldon + istio deployment
 module "seldon" {

--- a/k3d-modular/tekton.tf
+++ b/k3d-modular/tekton.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # using the tekton pipelines module to create a tekton pipelines deployment
 module "tekton-pipelines" {
   source = "../modules/tekton-pipelines-module"

--- a/k3d-modular/terraform.tf
+++ b/k3d-modular/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/k3d-modular/variables.tf
+++ b/k3d-modular/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # enable services
 variable "enable_container_registry" {
   description = "Enable K3D registry deployment"

--- a/modules/cert-manager-module/cert_manager.tf
+++ b/modules/cert-manager-module/cert_manager.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a namespace for cert-manager resources
 resource "kubernetes_namespace" "cert-manager-ns" {
   metadata {

--- a/modules/cert-manager-module/providers.tf
+++ b/modules/cert-manager-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the cert-manager module
 terraform {
   required_providers {

--- a/modules/cert-manager-module/variables.tf
+++ b/modules/cert-manager-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Helm chart version. If this is not specified, the latest version is installed.
 variable "chart_version" {
   type    = string

--- a/modules/gcp-cloudsql-module/outputs.tf
+++ b/modules/gcp-cloudsql-module/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "zenml_server_url" {
   value = var.create_ingress_controller ? "https://${data.kubernetes_service.ingress-controller[0].status.0.load_balancer.0.ingress.0.ip}.nip.io/${var.ingress_path}" : "https://${var.ingress_controller_hostname}.nip.io/${var.ingress_path}"
 }

--- a/modules/gcp-cloudsql-module/sql.tf
+++ b/modules/gcp-cloudsql-module/sql.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 module "cloudsql" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/mysql"
   version = "11.0.0"

--- a/modules/gcp-cloudsql-module/terraform.tf
+++ b/modules/gcp-cloudsql-module/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/modules/gcp-cloudsql-module/variables.tf
+++ b/modules/gcp-cloudsql-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "project_id" {
   description = "The GCP project for your resources"
   type        = string

--- a/modules/istio-module/istio.tf
+++ b/modules/istio-module/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a namespace for istio resources
 resource "kubernetes_namespace" "istio-ns" {
   metadata {

--- a/modules/istio-module/outputs.tf
+++ b/modules/istio-module/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-ip-address" {
   value = data.kubernetes_service.istio_ingress.status.0.load_balancer.0.ingress.0.ip
 }

--- a/modules/istio-module/providers.tf
+++ b/modules/istio-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the seldon module
 terraform {
   required_providers {

--- a/modules/istio-module/variables.tf
+++ b/modules/istio-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "namespace" {
   type    = string
   default = "istio-system"

--- a/modules/kserve-module/knative_serving.tf
+++ b/modules/kserve-module/knative_serving.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "null_resource" "knative-serving" {
   triggers = {
     knative_version = var.knative_version

--- a/modules/kserve-module/kserve.tf
+++ b/modules/kserve-module/kserve.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 resource "null_resource" "kserve" {
   triggers = {
     kserve_version = var.kserve_version

--- a/modules/kserve-module/output.tf
+++ b/modules/kserve-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "kserve-base-URL" {
   value = "https://${var.kserve_domain}"
 }

--- a/modules/kserve-module/providers.tf
+++ b/modules/kserve-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/modules/kserve-module/variables.tf
+++ b/modules/kserve-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "knative_version" {
   type    = string
   default = "1.8.1"

--- a/modules/kubeflow-pipelines-module/kubeflow.tf
+++ b/modules/kubeflow-pipelines-module/kubeflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up kubeflow pipelines
 resource "null_resource" "kubeflow" {
   triggers = {

--- a/modules/kubeflow-pipelines-module/output.tf
+++ b/modules/kubeflow-pipelines-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "pipelines-ui-URL" {
   value = "${var.tls_enabled ? "https" : "http"}://${var.ingress_host}"
 }

--- a/modules/kubeflow-pipelines-module/providers.tf
+++ b/modules/kubeflow-pipelines-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/modules/kubeflow-pipelines-module/variables.tf
+++ b/modules/kubeflow-pipelines-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "pipeline_version" {
   type    = string
   default = "1.8.3"

--- a/modules/minio-module/minio.tf
+++ b/modules/minio-module/minio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # Create namespace for minio
 resource "kubernetes_namespace" "minio-namespace" {
   metadata {

--- a/modules/minio-module/output.tf
+++ b/modules/minio-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "minio-server-endpoint" {
   value = var.ingress_host
 }

--- a/modules/minio-module/providers.tf
+++ b/modules/minio-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/modules/minio-module/variables.tf
+++ b/modules/minio-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "minio_storage_size" {
   description = "The size of the Minio storage volume"
   default     = "20Gi"

--- a/modules/mlflow-module/mlflow.tf
+++ b/modules/mlflow-module/mlflow.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the mlflow tracking server namespace
 resource "kubernetes_namespace" "mlflow" {
   metadata {

--- a/modules/mlflow-module/output.tf
+++ b/modules/mlflow-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "mlflow-tracking-URL" {
   value = "${var.tls_enabled ? "https" : "http"}://${var.ingress_host}"
 }

--- a/modules/mlflow-module/providers.tf
+++ b/modules/mlflow-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/modules/mlflow-module/secret.tf
+++ b/modules/mlflow-module/secret.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create a secret with user credentials
 resource "kubernetes_secret" "name" {
   metadata {

--- a/modules/mlflow-module/variables.tf
+++ b/modules/mlflow-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "namespace" {
   type    = string
   default = "mlflow"

--- a/modules/nginx-ingress-module/ingress.tf
+++ b/modules/nginx-ingress-module/ingress.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up the nginx ingress controller
 resource "kubernetes_namespace" "nginx-ns" {
   metadata {

--- a/modules/nginx-ingress-module/output.tf
+++ b/modules/nginx-ingress-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "ingress-controller-name" {
   value = helm_release.nginx-controller.name
 }

--- a/modules/nginx-ingress-module/providers.tf
+++ b/modules/nginx-ingress-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the nginx-ingress module
 terraform {
   required_providers {

--- a/modules/nginx-ingress-module/variables.tf
+++ b/modules/nginx-ingress-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "namespace" {
   type    = string
   default = "ingress-nginx"

--- a/modules/seldon-module/istio.tf
+++ b/modules/seldon-module/istio.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # the seldon istio ingress gateway
 # cannot use kubernetes_manifest resource since it practically 
 # doesn't support CRDs. Going with kubectl instead.

--- a/modules/seldon-module/output.tf
+++ b/modules/seldon-module/output.tf
@@ -1,0 +1,4 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+

--- a/modules/seldon-module/providers.tf
+++ b/modules/seldon-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the seldon module
 terraform {
   required_providers {

--- a/modules/seldon-module/seldon.tf
+++ b/modules/seldon-module/seldon.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # creating the namespace for the seldon deployment
 resource "kubernetes_namespace" "seldon-ns" {
   metadata {

--- a/modules/seldon-module/variables.tf
+++ b/modules/seldon-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 
 variable "namespace" {
   type    = string

--- a/modules/tekton-pipelines-module/output.tf
+++ b/modules/tekton-pipelines-module/output.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "pipelines-ui-URL" {
   value = "${var.tls_enabled ? "https" : "http"}://${var.ingress_host}"
 }

--- a/modules/tekton-pipelines-module/providers.tf
+++ b/modules/tekton-pipelines-module/providers.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers required by the mlflow module
 terraform {
   required_providers {

--- a/modules/tekton-pipelines-module/tekton.tf
+++ b/modules/tekton-pipelines-module/tekton.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # set up tekton pipelines
 resource "null_resource" "tekton" {
   triggers = {

--- a/modules/tekton-pipelines-module/variables.tf
+++ b/modules/tekton-pipelines-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 variable "pipeline_version" {
   type    = string
   default = "0.42.0"

--- a/modules/zenml-module/outputs.tf
+++ b/modules/zenml-module/outputs.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 output "zenml_server_url" {
   value = "https://${var.ingress_host}"
 }

--- a/modules/zenml-module/terraform.tf
+++ b/modules/zenml-module/terraform.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # defining the providers for the recipe module
 terraform {
   required_providers {

--- a/modules/zenml-module/variables.tf
+++ b/modules/zenml-module/variables.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 
 variable "chart_version" {
   description = "The ZenML chart version to use. Leave empty to use the latest."

--- a/modules/zenml-module/zen_server.tf
+++ b/modules/zenml-module/zen_server.tf
@@ -1,3 +1,7 @@
+# DEPRECATION WARNING: This code has been deprecated
+# The maintained & current code can be found at src/mlstacks/terraform/
+# under the same relative location.
+
 # create the ZenML Server deployment
 resource "kubernetes_namespace" "zen-server" {
   metadata {


### PR DESCRIPTION
This pull request deprecates the old code and provides a warning message indicating that the code has been deprecated. The maintained and current code can be found at src/mlstacks/terraform/ under the same relative location.

Created this PR following feedback from OSS contributors that it was confusing. Hopefully this makes it clearer.