### PR TITLE
Update provider configuration in terraform-aws.tf

### DIFF
--- a/src/mlstacks/terraform/remote-state-terraform-config/terraform-aws.tf
+++ b/src/mlstacks/terraform/remote-state-terraform-config/terraform-aws.tf
@@ -1,8 +1,13 @@
 # defining the providers for the recipe module
 terraform {
   required_providers {
-    google = {
-      source = "hashicorp/google"
+    aws = {
+      source = "hashicorp/aws"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "3.1.0"
     }
 
     local = {
@@ -40,6 +45,6 @@ terraform {
   required_version = ">= 0.14.8"
 }
 
-provider "google" {
-  project = var.project_id
+provider "aws" {
+  region = var.region
 }


### PR DESCRIPTION
This pull request updates the provider configuration in the terraform-aws.tf file to use the AWS provider instead of the Google provider. This change ensures that the correct provider is used for AWS deployments.

This was causing errors for Ubuntu users, but (oddly) not for Mac users. I actually am not quite sure how this was ever working for Mac users, at least since I added remote state.