### PR TITLE
Add label studio component

### DIFF
--- a/src/mlstacks/constants.py
+++ b/src/mlstacks/constants.py
@@ -17,6 +17,7 @@ from typing import Dict, List
 MLSTACKS_PACKAGE_NAME = "mlstacks"
 MLSTACKS_INITIALIZATION_FILE_FLAG = "IGNORE_ME"
 MLSTACKS_STACK_COMPONENT_FLAGS = [
+    "annotator",
     "artifact_store",
     "container_registry",
     "experiment_tracker",  # takes flavor
@@ -26,6 +27,7 @@ MLSTACKS_STACK_COMPONENT_FLAGS = [
     "step_operator",  # takes flavor
 ]
 ALLOWED_FLAVORS = {
+    "annotator": ["label_studio"],
     "artifact_store": ["s3", "gcp", "minio"],
     "container_registry": ["gcp", "aws", "default"],
     "experiment_tracker": ["mlflow"],
@@ -43,7 +45,8 @@ ALLOWED_FLAVORS = {
 }
 ALLOWED_COMPONENT_TYPES: Dict[str, Dict[str, List[str]]] = {
     "aws": {
-        "artifact_store": ["s3"],
+        "annotator": ["huggingface"],
+        "artifact_store": ["s3"],        
         "container_registry": ["aws"],
         "experiment_tracker": ["mlflow"],
         "orchestrator": [
@@ -59,6 +62,7 @@ ALLOWED_COMPONENT_TYPES: Dict[str, Dict[str, List[str]]] = {
     },
     "azure": {},
     "gcp": {
+        "annotator": ["huggingface"],
         "artifact_store": ["gcp"],
         "container_registry": ["gcp"],
         "experiment_tracker": ["mlflow"],
@@ -72,6 +76,9 @@ ALLOWED_COMPONENT_TYPES: Dict[str, Dict[str, List[str]]] = {
         "mlops_platform": ["zenml"],
         "model_deployer": ["seldon"],
         "step_operator": ["vertex"],
+    },
+    "huggingface": {
+        "annotator": ["label_studio"],
     },
     "k3d": {
         "artifact_store": ["minio"],

--- a/src/mlstacks/enums.py
+++ b/src/mlstacks/enums.py
@@ -40,6 +40,7 @@ class ComponentFlavorEnum(str, Enum):
     GCP = "gcp"
     KUBEFLOW = "kubeflow"
     KUBERNETES = "kubernetes"
+    LABEL_STUDIO = "label_studio"
     MINIO = "minio"
     MLFLOW = "mlflow"
     S3 = "s3"
@@ -65,6 +66,7 @@ class ProviderEnum(str, Enum):
     AZURE = "azure"
     GCP = "gcp"
     K3D = "k3d"
+    HUGGINGFACE = "huggingface"
 
 
 class AnalyticsEventsEnum(str, Enum):

--- a/src/mlstacks/terraform/gcp-modular/label_studio_hf.tf
+++ b/src/mlstacks/terraform/gcp-modular/label_studio_hf.tf
@@ -1,0 +1,27 @@
+provider "huggingface-spaces" {
+  # alias   = "strickvl"  
+  token = var.huggingface_token
+}
+
+# using the labelstudio huggingface module to create a label studio space on huggingface
+
+module "label_studio_hf" {
+  source = "../modules/label-studio-hf-module"
+  # providers = {
+  #   huggingface-spaces.strickvl = huggingface-spaces.strickvl
+  # }
+  count = var.enable_annotator ? 1 : 0
+  huggingface_token = var.huggingface_token
+  enable_annotator = var.enable_annotator
+}
+
+output "module_huggingface_token" {
+  value = length(module.label_studio_hf) > 0 ? module.label_studio_hf[0].huggingface_token_passed : ""
+  sensitive = true
+}
+
+output "token_hash" {
+  value     = sha256(module.label_studio_hf[0].huggingface_token_passed)
+  sensitive = true
+}
+

--- a/src/mlstacks/terraform/gcp-modular/terraform.tf
+++ b/src/mlstacks/terraform/gcp-modular/terraform.tf
@@ -29,10 +29,15 @@ terraform {
       source  = "loafoe/htpasswd"
       version = "1.0.3"
     }
+
+    huggingface-spaces = {
+      source  = "strickvl/huggingface-spaces"
+      version = ">= 0.0.4"  # Specify the version or version constraint here
+    }
   }
 
   backend "local" {
-    config = {}
+    # config = {}
   }
 
   required_version = ">= 0.14.8"

--- a/src/mlstacks/terraform/gcp-modular/variables.tf
+++ b/src/mlstacks/terraform/gcp-modular/variables.tf
@@ -27,6 +27,20 @@ variable "enable_experiment_tracker_mlflow" {
   description = "Enable MLflow deployment"
   default     = false
 }
+
+variable "enable_annotator" {
+  description = "Enable Label Studio deployment"
+  type        = bool
+  default     = true
+}
+
+variable "huggingface_token" {
+  description = "Huggingface token"
+  type        = string
+  # sensitive     = true
+  default     = ""
+}
+
 variable "enable_model_deployer_seldon" {
   description = "Enable Seldon deployment"
   default     = false

--- a/src/mlstacks/terraform/modules/label-studio-hf-module/label-studio.tf
+++ b/src/mlstacks/terraform/modules/label-studio-hf-module/label-studio.tf
@@ -1,0 +1,13 @@
+resource "huggingface-spaces_space" "ls_space" {
+  provider = huggingface-spaces
+  name     = "label-studio-hf-module-${formatdate("YYYYMMDD", timestamp())}"
+  private  = false
+  sdk      = "docker"
+  template = "LabelStudio/LabelStudio"
+
+  hardware = var.label_studio_hardware
+  sleep_time = var.label_studio_sleep_time
+  storage = "small"
+}
+
+

--- a/src/mlstacks/terraform/modules/label-studio-hf-module/outputs.tf
+++ b/src/mlstacks/terraform/modules/label-studio-hf-module/outputs.tf
@@ -1,0 +1,41 @@
+data "huggingface-spaces_space" "ls_space_data" {
+  id = huggingface-spaces_space.ls_space.id
+}
+
+output "label_studio_id" {
+  value = huggingface-spaces_space.ls_space.id
+}
+
+output "label_studio_name" {
+  value = data.huggingface-spaces_space.ls_space_data.name
+}
+
+output "label_studio_author" {
+  value = data.huggingface-spaces_space.ls_space_data.author
+}
+
+output "label_studio_last_modified" {
+  value = data.huggingface-spaces_space.ls_space_data.last_modified
+}
+
+output "label_studio_likes" {
+  value = data.huggingface-spaces_space.ls_space_data.likes
+}
+
+output "label_studio_private" {
+  value = data.huggingface-spaces_space.ls_space_data.private
+}
+
+output "label_studio_sdk" {
+  value = data.huggingface-spaces_space.ls_space_data.sdk
+}
+
+output "label_studio_hardware" {
+  value = data.huggingface-spaces_space.ls_space_data.hardware
+}
+
+output "huggingface_token_passed" {
+  value = var.huggingface_token
+}
+
+

--- a/src/mlstacks/terraform/modules/label-studio-hf-module/providers.tf
+++ b/src/mlstacks/terraform/modules/label-studio-hf-module/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    huggingface-spaces = {
+      source = "strickvl/huggingface-spaces"
+      version = ">= 0.0.4"
+      # configuration_aliases = [huggingface-spaces.strickvl]
+    }
+  }
+}

--- a/src/mlstacks/terraform/modules/label-studio-hf-module/variables.tf
+++ b/src/mlstacks/terraform/modules/label-studio-hf-module/variables.tf
@@ -1,0 +1,69 @@
+variable "huggingface_token" {
+  type        = string
+  description = "The Hugging Face API token."
+  sensitive   = true
+}
+
+variable "enable_annotator" {
+  type        = bool
+  description = "Enable annotator for the Label Studio instance."
+  default     = false
+}
+
+variable "enable_persistent_storage" {
+  type        = bool
+  description = "Enable persistent storage for the Label Studio instance."
+  default     = false
+}
+
+variable "persistent_storage_size" {
+  type        = string
+  description = "The size of the persistent storage for the Label Studio instance."
+  default     = "small"
+}
+
+variable "label_studio_disable_signup_without_link" {
+  type        = bool
+  description = "Disable the signup without link for the Label Studio instance."
+  default     = false
+}
+
+variable "label_studio_username" {
+  type        = string
+  description = "The username for the Label Studio instance."
+  default     = "davidrd123@gmail.com"
+  sensitive = true
+}
+
+variable "label_studio_password" {
+  type        = string
+  description = "The password for the Label Studio instance."
+  default     = "mlstacks"
+  sensitive    = true
+}
+
+variable "label_studio_hardware" {
+  type        = string
+  description = "The hardware for the Label Studio instance."
+  default     = "cpu-basic"
+}
+
+variable "label_studio_template" {
+  type        = string
+  description = "The template for the Label Studio instance."
+  default     = "LabelStudio/LabelStudio"
+}
+
+variable "label_studio_sleep_time" {
+  type        = string
+  description = "The sleep time in seconds for the Label Studio instance. (gc_timeout)"
+  default     = "3600"
+}
+
+variable "label_studio_private" {
+  type        = bool
+  description = "The private flag for the Label Studio instance."
+  default     = false
+}
+
+

--- a/src/mlstacks/testing/label_studio_stack.yaml
+++ b/src/mlstacks/testing/label_studio_stack.yaml
@@ -1,0 +1,11 @@
+spec_version: 1
+spec_type: stack
+name: "quickstart_stack"
+provider: gcp
+default_region: "us-west2"
+default_tags:
+  deployed-by: "mlstacks"
+components:
+  - simple_component_label_studio.yaml
+  - simple_component_gcs.yaml
+

--- a/src/mlstacks/testing/simple_component_gcs.yaml
+++ b/src/mlstacks/testing/simple_component_gcs.yaml
@@ -1,0 +1,13 @@
+spec_version: 1
+spec_type: component
+component_type: "artifact_store"
+component_flavor: "gcp"
+name: "ls_stack_gcs_bucket"
+provider: gcp
+metadata:
+  config:
+    bucket_name: "ls_stack_gcs_bucket"
+    project_id: "supple-snow-244700"
+  tags:
+    deployed-by: "mlstacks"
+  region: "us-west2"

--- a/src/mlstacks/testing/simple_component_label_studio.yaml
+++ b/src/mlstacks/testing/simple_component_label_studio.yaml
@@ -1,0 +1,13 @@
+spec_version: 1
+spec_type: component
+component_type: "annotator"
+component_flavor: "label_studio"
+name: "quickstart_label_studio"
+provider: "huggingface"
+metadata:
+  config:
+    project_id: "supple-snow-244700"
+  tags:
+    deployed-by: "mlstacks"
+
+

--- a/src/mlstacks/utils/yaml_utils.py
+++ b/src/mlstacks/utils/yaml_utils.py
@@ -122,7 +122,7 @@ def load_stack_yaml(path: str) -> Stack:
     )
 
     for component in stack.components:
-        if component.provider != stack.provider:
+        if component.provider != stack.provider and component.provider != "huggingface":
             raise ValueError(STACK_COMPONENT_PROVIDER_MISMATCH_ERROR_MESSAGE)
 
     return stack


### PR DESCRIPTION

## Describe changes

I have created Terraform files in the `gcp-modular` directory to enable the deployment of a Label Studio component to a Hugging Face Space. This setup works when running `terraform apply` directly in the directory. However, I encounter issues when attempting to deploy using the `mlstacks deploy` command.

### Debugging Files Included

This PR includes a set of YAML configuration files located in `src/mlstacks/testing` used for debugging the deployment process of the new MLStacks component. These files are essential for replicating the deployment steps and troubleshooting the issues described.

### Steps to Reproduce the Error

To replicate the error I'm encountering with `mlstacks deploy`, execute the following command from within the `src/mlstacks/testing` directory:

```bash
python ../cli/cli.py deploy -f label_studio_stack.yaml -d
```

This results in the following error related to Terraform provider resolution:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/huggingface-spaces: provider registry registry.terraform.io does not have a provider named
registry.terraform.io/hashicorp/huggingface-spaces

Did you intend to use strickvl/huggingface-spaces? If so, you must specify that source address in each module which requires that provider. To see which modules are currently
depending on hashicorp/huggingface-spaces, run the following command:
    terraform providers
```

## Request for Assistance

I would appreciate guidance on resolving the provider resolution issue with `mlstacks deploy`. Any insights into potential misconfigurations or enhancements to the deployment scripts would be highly beneficial.

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation
      accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting
      `develop`. If your branch wasn't based on develop read
      [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/mlstacks/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of Changes

- [x] **New Feature**: Added Terraform configurations for deploying Label Studio as a component in a Hugging Face Space.
- [x] **Code Refactoring**: Introduced new constants and enumerations to support the configuration of the Label Studio component.
- [ ] **Bug Fix/Improvement**: (If applicable, describe any bug fixes or improvements here.)


