### PR TITLE
Update pip installation command for zenml package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: pip install -e .
 
       - name: Install zenml package
-        run: pip install -e git+https://github.com/zenml-io/zenml.git@develop#egg=zenml
+        run: pip install zenml
 
       - name: Check for broken dependencies
         run: pip check


### PR DESCRIPTION
This pull request updates the pip installation command for the zenml package. Previously, the command used a git URL, but now it uses a direct installation command. This change simplifies the installation process and ensures that the latest version of the package is installed.