### PR TITLE
Remove Python 3 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     uses: ./.github/workflows/setup-python-environment.yml
     with:
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     uses: ./.github/workflows/setup-python-environment.yml
     with:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     uses: ./.github/workflows/setup-python-environment.yml
     with:
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     uses: ./.github/workflows/lint-unit-test.yml
     with:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     uses: ./.github/workflows/lint-unit-test.yml
     with:
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     uses: ./.github/workflows/lint-unit-test.yml
     with:

--- a/.github/workflows/lint-unit-test.yml
+++ b/.github/workflows/lint-unit-test.yml
@@ -32,13 +32,12 @@ on:
         description: 'Python version'
         type: choice
         options:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
         required: false
-        default: '3.8'
+        default: '3.9'
       enable_tmate:
         description: 'Enable tmate session for debugging'
         type: choice
@@ -86,20 +85,8 @@ jobs:
 
       - name: Docstring check
         run: bash scripts/docstring.sh
-        # Only run the docstring check on ubuntu-latest and python 3.8
-        if: ${{ inputs.os == 'ubuntu-latest' && inputs.python-version == '3.8' }}
-
-    #   - name: Markdown link check
-    #     uses: gaurav-nelson/github-action-markdown-link-check@v1
-    #     with:
-    #       use-quiet-mode: 'yes'
-    #       use-verbose-mode: 'no'
-    #       folder-path: './examples, ./docs/book, ./src'
-    #       file-path: './README.md, ./LICENSE, ./RELEASE_NOTES.md, CODE-OF-CONDUCT.md, CONTRIBUTING.md, CLA.md, RELEASE_NOTES.md, ROADMAP.md'
-    #       config-file: .github/workflows/markdown_check_config.json
-    #     continue-on-error: true
-    #     # Only run the markdown link check on ubuntu-latest and python 3.8
-    #     if: ${{ inputs.os == 'ubuntu-latest' && inputs.python-version == '3.8' }}
+        # Only run the docstring check on ubuntu-latest and python 3.9
+        if: ${{ inputs.os == 'ubuntu-latest' && inputs.python-version == '3.9' }}
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/publish-pypi-package.yml
+++ b/.github/workflows/publish-pypi-package.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/lint-unit-test.yml
     with:
       os: "ubuntu-latest"
-      python-version: "3.8"
+      python-version: "3.9"
     secrets: inherit
 
   # checks zenml and mlstacks can be installed together in same environment
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install current package as editable
         run: pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -64,7 +63,7 @@ exclude = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.13"
+python = ">=3.9,<3.13"
 pydantic = { version = "~2.8" }
 pyyaml = { version = ">=6.0.1" }
 click = { version = "^8.0.1,<8.1.4" }
@@ -164,8 +163,8 @@ select = [
 ignore = ["COM812", "ISC001"]
 
 src = ["src", "tests"]
-# use Python 3.8 as the minimum version for autofixing
-target-version = "py38"
+# use Python 3.9 as the minimum version for autofixing
+target-version = "py39"
 ignore-init-module-imports = true
 # # Disable autofix for unused imports (`F401`).
 # unfixable = ["F401"]

--- a/src/mlstacks/analytics/client.py
+++ b/src/mlstacks/analytics/client.py
@@ -16,7 +16,7 @@ import datetime
 import logging
 import os
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Any, Optional, cast
 from uuid import uuid4
 
 import click
@@ -41,7 +41,7 @@ analytics.max_retries = 1
 CONFIG_FILENAME = "config.yaml"
 
 
-def on_error(error: Exception, batch: List[Dict[str, Any]]) -> None:
+def on_error(error: Exception, batch: list[dict[str, Any]]) -> None:
     """Custom error handler for Segment analytics.
 
     Args:
@@ -88,7 +88,7 @@ class MLStacksAnalyticsContext:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> bool:
@@ -109,7 +109,7 @@ class MLStacksAnalyticsContext:
     def track(
         self,
         event: AnalyticsEventsEnum,
-        properties: Optional[Dict[Any, Any]] = None,
+        properties: Optional[dict[Any, Any]] = None,
     ) -> Any:
         """Tracks event in Segment.
 
@@ -168,7 +168,7 @@ class MLStacksAnalyticsContext:
 
 def track_event(
     event: AnalyticsEventsEnum,
-    metadata: Optional[Dict[str, Any]] = None,
+    metadata: Optional[dict[str, Any]] = None,
 ) -> bool:
     """Track segment event if user opted-in.
 
@@ -195,7 +195,7 @@ class EventHandler:
     def __init__(
         self,
         event: AnalyticsEventsEnum,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ):
         """Initialization of the context manager.
 
@@ -204,7 +204,7 @@ class EventHandler:
             metadata: The metadata of the event.
         """
         self.event: AnalyticsEventsEnum = event
-        self.metadata: Dict[str, Any] = metadata or {}
+        self.metadata: dict[str, Any] = metadata or {}
 
     def __enter__(self) -> "EventHandler":
         """Enter function of the event handler.

--- a/src/mlstacks/constants.py
+++ b/src/mlstacks/constants.py
@@ -12,8 +12,6 @@
 #  permissions and limitations under the License.
 """MLStacks constants."""
 
-from typing import Dict, List
-
 MLSTACKS_PACKAGE_NAME = "mlstacks"
 MLSTACKS_INITIALIZATION_FILE_FLAG = "IGNORE_ME"
 MLSTACKS_STACK_COMPONENT_FLAGS = [
@@ -41,7 +39,7 @@ ALLOWED_FLAVORS = {
     "model_deployer": ["seldon"],
     "step_operator": ["sagemaker", "vertex"],
 }
-ALLOWED_COMPONENT_TYPES: Dict[str, Dict[str, List[str]]] = {
+ALLOWED_COMPONENT_TYPES: dict[str, dict[str, list[str]]] = {
     "aws": {
         "artifact_store": ["s3"],
         "container_registry": ["aws"],

--- a/src/mlstacks/models/component.py
+++ b/src/mlstacks/models/component.py
@@ -12,7 +12,7 @@
 #  permissions and limitations under the License.
 """Component model."""
 
-from typing import Dict, Optional
+from typing import Optional
 
 from pydantic import BaseModel, field_validator, model_validator
 
@@ -43,8 +43,8 @@ class ComponentMetadata(BaseModel):
         environment_variables: The environment variables for the component.
     """
 
-    config: Optional[Dict[str, str]] = None
-    environment_variables: Optional[Dict[str, str]] = None
+    config: Optional[dict[str, str]] = None
+    environment_variables: Optional[dict[str, str]] = None
 
 
 class Component(BaseModel):

--- a/src/mlstacks/models/stack.py
+++ b/src/mlstacks/models/stack.py
@@ -12,7 +12,7 @@
 #  permissions and limitations under the License.
 """Stack model."""
 
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
@@ -46,11 +46,11 @@ class Stack(BaseModel):
     name: str
     provider: ProviderEnum
     default_region: Optional[str] = None
-    default_tags: Optional[Dict[str, str]] = None
+    default_tags: Optional[dict[str, str]] = None
     deployment_method: Optional[DeploymentMethodEnum] = (
         DeploymentMethodEnum.KUBERNETES
     )
-    components: List[Component] = []
+    components: list[Component] = []
 
     @field_validator("name")
     @classmethod

--- a/src/mlstacks/utils/cli_utils.py
+++ b/src/mlstacks/utils/cli_utils.py
@@ -13,7 +13,7 @@
 """CLI utilities for mlstacks."""
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, Union
 
 import click
 from rich import box, table
@@ -138,7 +138,7 @@ def print_markdown_with_pager(text: str) -> None:
 
 
 def print_table(
-    obj: List[Dict[str, Any]],
+    obj: list[dict[str, Any]],
     title: Optional[str] = None,
     caption: Optional[str] = None,
     **columns: table.Column,
@@ -189,7 +189,7 @@ def print_table(
 
 
 def pretty_print_output_vals(
-    output_vals: Dict[str, str],
+    output_vals: dict[str, str],
 ) -> None:
     """Prints dictionary values as a rich table.
 

--- a/src/mlstacks/utils/terraform_utils.py
+++ b/src/mlstacks/utils/terraform_utils.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Optional, cast
 
 import pkg_resources
 import python_terraform
@@ -147,8 +147,8 @@ def _compose_enable_key(component: Component) -> str:
 
 
 def parse_and_extract_component_variables(
-    components: List[Component],
-) -> Dict[str, str]:
+    components: list[Component],
+) -> dict[str, str]:
     """Parse component variables.
 
     Args:
@@ -189,7 +189,7 @@ def parse_and_extract_component_variables(
     return component_variables
 
 
-def parse_and_extract_tf_vars(stack: Stack) -> Dict[str, Any]:
+def parse_and_extract_tf_vars(stack: Stack) -> dict[str, Any]:
     """Parse Terraform variables.
 
     Args:
@@ -228,8 +228,8 @@ def tf_definitions_present(
 
 def include_files(
     directory: str,  # noqa: ARG001
-    filenames: List[str],
-) -> List[str]:
+    filenames: list[str],
+) -> list[str]:
     """Include files in Terraform definitions.
 
     Args:
@@ -358,7 +358,7 @@ def populate_tf_definitions(
 def get_recipe_metadata(
     provider: ProviderEnum,
     base_config_dir: str = CONFIG_DIR,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Loads modular recipe metadata for a specific provider.
 
     Args:
@@ -458,7 +458,7 @@ def _tf_client_init(
     region: str,
     debug: bool = False,
     remote_state_bucket: Optional[str] = None,
-) -> Tuple[Any, Any, Any]:
+) -> tuple[Any, Any, Any]:
     """Initialize Terraform client.
 
     Args:
@@ -506,9 +506,9 @@ def _tf_client_init(
 
 def _tf_client_apply(
     client: python_terraform.Terraform,
-    tf_vars: Dict[str, Any],
+    tf_vars: dict[str, Any],
     debug: bool,
-) -> Tuple[Any, Any, Any]:
+) -> tuple[Any, Any, Any]:
     """Apply Terraform changes.
 
     Args:
@@ -548,9 +548,9 @@ def _tf_client_apply(
 
 def _tf_client_destroy(
     client: python_terraform.Terraform,
-    tf_vars: Dict[str, Any],
+    tf_vars: dict[str, Any],
     debug: bool,
-) -> Tuple[Any, Any, Any]:
+) -> tuple[Any, Any, Any]:
     """Destroy Terraform changes.
 
     Args:
@@ -580,7 +580,7 @@ def _tf_client_output(
     runner: TerraformRunner,
     state_path: str,
     output_key: Optional[str] = None,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Get Terraform outputs.
 
     Args:
@@ -658,7 +658,7 @@ def populate_remote_state_tf_definitions(
 def write_remote_state_tf_variables(
     bucket_name: str,
     stack: Stack,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Writes remote state variables to a json file.
 
     Args:
@@ -968,7 +968,7 @@ def get_remote_state_bucket(stack_path: str) -> str:
 def get_stack_outputs(
     stack_path: str,
     output_key: Optional[str] = None,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Get stack outputs.
 
     Args:
@@ -1023,7 +1023,7 @@ def verify_infracost_installed() -> bool:
         return False
 
 
-def _get_infracost_vars(variables: Dict[str, Any]) -> Dict[str, str]:
+def _get_infracost_vars(variables: dict[str, Any]) -> dict[str, str]:
     """Get Infracost variables.
 
     Args:

--- a/src/mlstacks/utils/yaml_utils.py
+++ b/src/mlstacks/utils/yaml_utils.py
@@ -13,7 +13,7 @@
 """Utility functions for loading YAML files into Python objects."""
 
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 import yaml
 
@@ -25,7 +25,7 @@ from mlstacks.models.component import (
 from mlstacks.models.stack import Stack
 
 
-def load_yaml_as_dict(path: Union[Path, str]) -> Dict[str, Any]:
+def load_yaml_as_dict(path: Union[Path, str]) -> dict[str, Any]:
     """Loads a yaml file as a dictionary.
 
     Args:

--- a/src/mlstacks/utils/zenml_utils.py
+++ b/src/mlstacks/utils/zenml_utils.py
@@ -12,8 +12,6 @@
 #  permissions and limitations under the License.
 """Utilities for mlstacks-ZenML interaction."""
 
-from typing import List
-
 from mlstacks.constants import ALLOWED_FLAVORS
 from mlstacks.models.component import Component
 from mlstacks.models.stack import Stack
@@ -21,7 +19,7 @@ from mlstacks.models.stack import Stack
 
 def has_valid_flavor_combinations(
     stack: Stack,
-    components: List[Component],
+    components: list[Component],
 ) -> bool:
     """Returns true if flavors have a valid combination.
 

--- a/tests/integration/docker-compose.localstack.yml
+++ b/tests/integration/docker-compose.localstack.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 
 services:
   localstack:


### PR DESCRIPTION
Python 3.8 is EOL on October 1st, so we're removing support for it.